### PR TITLE
feat: add Glama badge to README for server status visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,13 @@
 [![CI](https://github.com/freema/firefox-devtools-mcp/workflows/CI/badge.svg)](https://github.com/freema/firefox-devtools-mcp/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/freema/firefox-devtools-mcp/branch/main/graph/badge.svg)](https://codecov.io/gh/freema/firefox-devtools-mcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Glama](https://glama.ai/mcp/servers/@freema/firefox-devtools-mcp/badge)](https://glama.ai/mcp/servers/@freema/firefox-devtools-mcp)
 
 Model Context Protocol server for automating Firefox via WebDriver BiDi (through Selenium WebDriver). Works with Claude Code, Claude Desktop, Cursor, Cline and other MCP clients.
 
 Repository: https://github.com/freema/firefox-devtools-mcp
+
+> **Note**: This MCP server requires a local Firefox browser installation and cannot run on cloud hosting services like glama.ai. Use `npx firefox-devtools-mcp@latest` to run locally, or use Docker with the provided Dockerfile.
 
 ## Requirements
 


### PR DESCRIPTION
This pull request updates the `README.md` to improve project visibility and clarify usage requirements. The most important changes are:

Project visibility:

* Added a Glama badge to the top of the `README.md` to show project status on Glama.

Usage clarification:

* Added a note explaining that the MCP server requires a local Firefox installation and cannot run on cloud hosting services like glama.ai, with instructions for running locally or with Docker.