### PR TITLE
fix: move geckodriver to dependencies to fix connection timeout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "firefox-devtools-mcp",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "firefox-devtools-mcp",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.1",
+        "geckodriver": "^6.0.2",
         "selenium-webdriver": "^4.36.0",
         "ws": "^8.18.3",
         "yargs": "^17.7.2"
@@ -30,7 +31,6 @@
         "eslint": "^8.57.1",
         "eslint-config-prettier": "^10.1.5",
         "eslint-plugin-prettier": "^5.4.0",
-        "geckodriver": "^6.0.2",
         "prettier": "^3.5.3",
         "tsup": "^8.0.0",
         "tsx": "^4.7.0",
@@ -1674,7 +1674,6 @@
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.18.0.tgz",
       "integrity": "sha512-HdzDrRs+ywAqbXGKqe1i/bLtCv47plz4TvsHFH3j729OooT5VH38ctFn5aLXgECmiAKDkmH/A6kOq2Zh5DIxww==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.1.2",
@@ -1691,7 +1690,6 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1704,7 +1702,6 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -1717,7 +1714,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
       "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -1733,7 +1729,6 @@
       "version": "2.8.7",
       "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.7.tgz",
       "integrity": "sha512-8daf29EMM3gUpH/vSBSCYo2bY/wbamgRPxPpE2b+cDnbOLBHAcZikWad79R4Guemth/qtipzEHrZMq1lFXxWIA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "bun": ">=0.7.0",
@@ -1781,7 +1776,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -2253,7 +2247,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.1.tgz",
       "integrity": "sha512-G7Cqgaelq68XHJNGlZ7lrNQyhZGsFqpwtGFexqUv4IQdjKoSYF7ipZ9UuTJZUSQXFj/XaoBLuEVIVqr8EJngEQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
@@ -3043,7 +3036,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-6.0.2.tgz",
       "integrity": "sha512-5C4cejCvcz4yFiBHP0FEWKwSZKhr3WMkshNBQ7cSb9PqfrdSNVAbe2RTNxsdBkk3Fmqcu6PNnffiJa0T+JZGFQ==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -3305,7 +3297,6 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -3319,7 +3310,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -3710,7 +3700,6 @@
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
       "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
@@ -3724,7 +3713,6 @@
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.8.4.tgz",
       "integrity": "sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/loupe": {
@@ -3897,7 +3885,6 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.3.5.tgz",
       "integrity": "sha512-TIALaZ8AjtEHFOZj1wRreDfaobCybvzPkvevpup/XtKOha3TmJWSwrh0ghc/QwAdAtt6oqIN6z6eIlo+HbDnzg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -4510,7 +4497,6 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
       "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -4650,7 +4636,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.0.0.tgz",
       "integrity": "sha512-YwJwe5a51WlK7KbOJREPdjNrpViQBI3p4T50lfwPuDhZnE3XGVTlGvi+aolc5+RvxDD6bnUmjVsU9n1eboLUYw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firefox-devtools-mcp",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Model Context Protocol (MCP) server for Firefox DevTools automation",
   "author": "freema",
   "license": "MIT",
@@ -58,6 +58,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.17.1",
+    "geckodriver": "^6.0.2",
     "selenium-webdriver": "^4.36.0",
     "ws": "^8.18.3",
     "yargs": "^17.7.2"
@@ -75,7 +76,6 @@
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-prettier": "^5.4.0",
-    "geckodriver": "^6.0.2",
     "prettier": "^3.5.3",
     "tsup": "^8.0.0",
     "tsx": "^4.7.0",

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -3,6 +3,6 @@
  */
 
 export const SERVER_NAME = 'firefox-devtools';
-export const SERVER_VERSION = '0.2.1';
+export const SERVER_VERSION = '0.2.4';
 
 export const DEFAULT_HEADLESS = false;

--- a/tests/config/constants.test.ts
+++ b/tests/config/constants.test.ts
@@ -23,7 +23,7 @@ describe('Constants', () => {
     });
 
     it('should match package.json version', () => {
-      expect(SERVER_VERSION).toBe('0.2.1');
+      expect(SERVER_VERSION).toBe('0.2.4');
     });
 
     it('should be a non-empty string', () => {

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -16,7 +16,7 @@ describe('Smoke Tests', () => {
 
     it('should have valid server version', () => {
       expect(SERVER_VERSION).toMatch(/^\d+\.\d+\.\d+/);
-      expect(SERVER_VERSION).toBe('0.2.1');
+      expect(SERVER_VERSION).toBe('0.2.4');
     });
   });
 


### PR DESCRIPTION
Fixes the "Connection closed" error that occurred when running the MCP server from different working directories. The issue was that geckodriver was in devDependencies, so it wasn't installed when users ran `npx firefox-devtools-mcp@latest` or `claude mcp add firefox-devtools`.

Changes:
- Move geckodriver from devDependencies to dependencies
- Update version to 0.2.4

This ensures geckodriver is always available regardless of the working directory, fixing the MCP connection timeout issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)