### PR TITLE
Fix MCP connection timeout and closure errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "firefox-devtools-mcp",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "firefox-devtools-mcp",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.1",


### PR DESCRIPTION
The previous module detection logic failed when running via npx due to symlink resolution differences. This caused the server to exit immediately without starting, resulting in "MCP error -32000: Connection closed".

The fix uses realpathSync() to fully resolve both the module path and script path before comparison, handling symlinks and path normalization across different execution contexts (npx, node, direct execution).

Fixes the issue where:
- Connection failed after ~1s with "Connection closed" error
- Server worked in development but failed when installed via npx