### PR TITLE
Navigate to localhost development server

### DIFF
--- a/src/firefox/snapshot/manager.ts
+++ b/src/firefox/snapshot/manager.ts
@@ -43,10 +43,12 @@ export class SnapshotManager {
 
       // Try multiple potential locations
       const possiblePaths = [
-        // Production: relative to compiled dist/index.js location
-        resolve(currentDir, '../../snapshot.injected.global.js'),
-        // Alternative: relative to current working directory
+        // Production: relative to bundled dist/index.js (same directory)
+        resolve(currentDir, 'snapshot.injected.global.js'),
+        // Development: relative to current working directory
         resolve(process.cwd(), 'dist/snapshot.injected.global.js'),
+        // npx: package is in node_modules, try to find it relative to the binary
+        resolve(currentDir, '../snapshot.injected.global.js'),
       ];
 
       const attemptedPaths: string[] = [];


### PR DESCRIPTION
The previous path resolution assumed the file structure was preserved after bundling, but tsup bundles everything into a single dist/index.js. This caused the snapshot.injected.global.js bundle to not be found when running via npx.

The fix updates the path resolution to correctly look for the bundle in the same directory as the bundled index.js (dist/).