### PR TITLE
fix: remove tests from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,6 @@ jobs:
           npm run typecheck
           npm run lint
           npm run format:check
-          npm run test:run
           npm run build
 
       - name: Publish


### PR DESCRIPTION
Tests are already run on main branch CI before merge. Running them again during publish causes failures because the build step runs after tests, but integration tests require the built bundle.
