### PR TITLE
Optimize MCP tool definitions for efficiency

### DIFF
--- a/src/tools/console.ts
+++ b/src/tools/console.ts
@@ -13,36 +13,35 @@ import type { McpToolResponse } from '../types/common.js';
 
 export const listConsoleMessagesTool = {
   name: 'list_console_messages',
-  description:
-    'List console messages for the selected tab since the last navigation. Use filters (level, limit, sinceMs, textContains, source) to focus on recent and relevant logs.',
+  description: 'List console messages. Supports filtering by level, time, text, source.',
   inputSchema: {
     type: 'object',
     properties: {
       level: {
         type: 'string',
         enum: ['debug', 'info', 'warn', 'error'],
-        description: 'Filter by console message level',
+        description: 'Filter by level',
       },
       limit: {
         type: 'number',
-        description: 'Maximum number of messages to return (default: 50)',
+        description: 'Max messages (default: 50)',
       },
       sinceMs: {
         type: 'number',
-        description: 'Only show messages from the last N milliseconds (filters by timestamp)',
+        description: 'Only last N ms',
       },
       textContains: {
         type: 'string',
-        description: 'Filter messages by text content (case-insensitive substring match)',
+        description: 'Text filter (case-insensitive)',
       },
       source: {
         type: 'string',
-        description: 'Filter messages by source (e.g., "console-api", "javascript", "network")',
+        description: 'Filter by source',
       },
       format: {
         type: 'string',
         enum: ['text', 'json'],
-        description: 'Output format: text (default, human-readable) or json (structured data)',
+        description: 'Output format (default: text)',
       },
     },
   },
@@ -50,8 +49,7 @@ export const listConsoleMessagesTool = {
 
 export const clearConsoleMessagesTool = {
   name: 'clear_console_messages',
-  description:
-    'Clear the collected console messages. TIP: Clear before a new measurement to keep output focused.',
+  description: 'Clear collected console messages.',
   inputSchema: {
     type: 'object',
     properties: {},

--- a/src/tools/input.ts
+++ b/src/tools/input.ts
@@ -31,18 +31,17 @@ function handleUidError(error: Error, uid: string): Error {
 // Tool definitions
 export const clickByUidTool = {
   name: 'click_by_uid',
-  description:
-    'Click an element identified by its UID. Supports double-click via dblClick=true. TIP: Take a fresh snapshot if the UID becomes stale.',
+  description: 'Click element by UID. Set dblClick for double-click.',
   inputSchema: {
     type: 'object',
     properties: {
       uid: {
         type: 'string',
-        description: 'The UID of the element to click',
+        description: 'Element UID from snapshot',
       },
       dblClick: {
         type: 'boolean',
-        description: 'If true, performs a double-click (default: false)',
+        description: 'Double-click (default: false)',
       },
     },
     required: ['uid'],
@@ -51,14 +50,13 @@ export const clickByUidTool = {
 
 export const hoverByUidTool = {
   name: 'hover_by_uid',
-  description:
-    'Hover over an element identified by its UID. TIP: Take a fresh snapshot if the UID becomes stale.',
+  description: 'Hover over element by UID.',
   inputSchema: {
     type: 'object',
     properties: {
       uid: {
         type: 'string',
-        description: 'The UID of the element to hover over',
+        description: 'Element UID from snapshot',
       },
     },
     required: ['uid'],
@@ -67,18 +65,17 @@ export const hoverByUidTool = {
 
 export const fillByUidTool = {
   name: 'fill_by_uid',
-  description:
-    'Fill a text input or textarea identified by its UID. Keep values short and safe. TIP: Take a fresh snapshot if the UID becomes stale.',
+  description: 'Fill text input/textarea by UID.',
   inputSchema: {
     type: 'object',
     properties: {
       uid: {
         type: 'string',
-        description: 'The UID of the input element',
+        description: 'Input element UID from snapshot',
       },
       value: {
         type: 'string',
-        description: 'The text value to fill into the input',
+        description: 'Text to fill',
       },
     },
     required: ['uid', 'value'],
@@ -87,18 +84,17 @@ export const fillByUidTool = {
 
 export const dragByUidToUidTool = {
   name: 'drag_by_uid_to_uid',
-  description:
-    'Simulate HTML5 drag-and-drop from one UID to another using JS drag events. May not work with all custom libraries.',
+  description: 'Drag element to another (HTML5 drag events).',
   inputSchema: {
     type: 'object',
     properties: {
       fromUid: {
         type: 'string',
-        description: 'The UID of the element to drag',
+        description: 'Source element UID',
       },
       toUid: {
         type: 'string',
-        description: 'The UID of the target element to drop onto',
+        description: 'Target element UID',
       },
     },
     required: ['fromUid', 'toUid'],
@@ -107,23 +103,23 @@ export const dragByUidToUidTool = {
 
 export const fillFormByUidTool = {
   name: 'fill_form_by_uid',
-  description: 'Fill multiple form fields in one call using an array of {uid, value} pairs.',
+  description: 'Fill multiple form fields at once.',
   inputSchema: {
     type: 'object',
     properties: {
       elements: {
         type: 'array',
-        description: 'Array of form field UIDs with their values',
+        description: 'Array of {uid, value} pairs',
         items: {
           type: 'object',
           properties: {
             uid: {
               type: 'string',
-              description: 'The UID of the form field',
+              description: 'Field UID',
             },
             value: {
               type: 'string',
-              description: 'The value to fill',
+              description: 'Field value',
             },
           },
           required: ['uid', 'value'],
@@ -136,18 +132,17 @@ export const fillFormByUidTool = {
 
 export const uploadFileByUidTool = {
   name: 'upload_file_by_uid',
-  description:
-    'Upload a file into an <input type="file"> element identified by its UID. The file path must be accessible to the server.',
+  description: 'Upload file to file input by UID.',
   inputSchema: {
     type: 'object',
     properties: {
       uid: {
         type: 'string',
-        description: 'The UID of the file input element',
+        description: 'File input UID from snapshot',
       },
       filePath: {
         type: 'string',
-        description: 'Local filesystem path to the file to upload',
+        description: 'Local file path',
       },
     },
     required: ['uid', 'filePath'],

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -14,62 +14,60 @@ import type { McpToolResponse } from '../types/common.js';
 // Tool definitions
 export const listNetworkRequestsTool = {
   name: 'list_network_requests',
-  description:
-    'List recent network requests across all tabs. Network capture is always on. Use filters (limit, sinceMs, urlContains, method, status, resourceType) and detail (summary|min|full) to control output. Each entry includes a stable id for use with get_network_request.',
+  description: 'List network requests. Returns IDs for get_network_request.',
   inputSchema: {
     type: 'object' as const,
     properties: {
       limit: {
         type: 'number',
-        description: 'Maximum number of requests to return (default: 50)',
+        description: 'Max requests (default: 50)',
       },
       sinceMs: {
         type: 'number',
-        description: 'Return only requests newer than N milliseconds ago',
+        description: 'Only last N ms',
       },
       urlContains: {
         type: 'string',
-        description: 'Filter requests by URL substring (case-insensitive)',
+        description: 'URL filter (case-insensitive)',
       },
       method: {
         type: 'string',
-        description: 'Filter by HTTP method (GET, POST, etc., case-insensitive)',
+        description: 'HTTP method filter',
       },
       status: {
         type: 'number',
-        description: 'Filter by exact HTTP status code',
+        description: 'Exact status code',
       },
       statusMin: {
         type: 'number',
-        description: 'Filter by minimum HTTP status code',
+        description: 'Min status code',
       },
       statusMax: {
         type: 'number',
-        description: 'Filter by maximum HTTP status code',
+        description: 'Max status code',
       },
       isXHR: {
         type: 'boolean',
-        description: 'Filter by XHR/fetch requests only',
+        description: 'XHR/fetch only',
       },
       resourceType: {
         type: 'string',
-        description: 'Filter by resource type (case-insensitive)',
+        description: 'Resource type filter',
       },
       sortBy: {
         type: 'string',
         enum: ['timestamp', 'duration', 'status'],
-        description: 'Sort requests by field (default: timestamp descending)',
+        description: 'Sort field (default: timestamp)',
       },
       detail: {
         type: 'string',
         enum: ['summary', 'min', 'full'],
-        description:
-          'Output detail level: summary (default), min (compact JSON), full (includes headers)',
+        description: 'Detail level (default: summary)',
       },
       format: {
         type: 'string',
         enum: ['text', 'json'],
-        description: 'Output format: text (default, human-readable) or json (structured data)',
+        description: 'Output format (default: text)',
       },
     },
   },
@@ -77,23 +75,22 @@ export const listNetworkRequestsTool = {
 
 export const getNetworkRequestTool = {
   name: 'get_network_request',
-  description:
-    'Get detailed information about a network request by id (recommended). URL lookup is available as a fallback but may match multiple requests.',
+  description: 'Get request details by ID. URL lookup as fallback.',
   inputSchema: {
     type: 'object' as const,
     properties: {
       id: {
         type: 'string',
-        description: 'The request ID from list_network_requests (recommended)',
+        description: 'Request ID from list_network_requests',
       },
       url: {
         type: 'string',
-        description: 'The URL of the request (fallback, may match multiple requests)',
+        description: 'URL fallback (may match multiple)',
       },
       format: {
         type: 'string',
         enum: ['text', 'json'],
-        description: 'Output format: text (default) or json (structured data)',
+        description: 'Output format (default: text)',
       },
     },
   },

--- a/src/tools/pages.ts
+++ b/src/tools/pages.ts
@@ -8,8 +8,7 @@ import type { McpToolResponse } from '../types/common.js';
 // Tool definitions
 export const listPagesTool = {
   name: 'list_pages',
-  description:
-    'List all open tabs with index, title, and URL. The currently selected tab is marked. Use the index with select_page.',
+  description: 'List open tabs (index, title, URL). Selected tab is marked.',
   inputSchema: {
     type: 'object',
     properties: {},
@@ -18,14 +17,13 @@ export const listPagesTool = {
 
 export const newPageTool = {
   name: 'new_page',
-  description:
-    'Open a new tab and navigate it to the provided URL. Returns the new tab index in the response.',
+  description: 'Open new tab at URL. Returns tab index.',
   inputSchema: {
     type: 'object',
     properties: {
       url: {
         type: 'string',
-        description: 'URL to load in a new page',
+        description: 'Target URL',
       },
     },
     required: ['url'],
@@ -34,13 +32,13 @@ export const newPageTool = {
 
 export const navigatePageTool = {
   name: 'navigate_page',
-  description: 'Navigate the currently selected tab to the provided URL.',
+  description: 'Navigate selected tab to URL.',
   inputSchema: {
     type: 'object',
     properties: {
       url: {
         type: 'string',
-        description: 'URL to navigate the page to',
+        description: 'Target URL',
       },
     },
     required: ['url'],
@@ -49,28 +47,21 @@ export const navigatePageTool = {
 
 export const selectPageTool = {
   name: 'select_page',
-  description:
-    'Select the active tab by index (preferred), or by matching URL/title. Index takes precedence when multiple parameters are provided.',
+  description: 'Select active tab by index, URL, or title. Index takes precedence.',
   inputSchema: {
     type: 'object',
     properties: {
       pageIdx: {
         type: 'number',
-        description:
-          'The index of the page to select (e.g., 0, 1, 2). ' +
-          'Use list_pages first to see all available page indices. Most reliable method.',
+        description: 'Tab index (0-based, most reliable)',
       },
       url: {
         type: 'string',
-        description:
-          'Select page by URL (partial match, case-insensitive). ' +
-          'Example: "github.com" will match "https://github.com/user/repo"',
+        description: 'URL substring (case-insensitive)',
       },
       title: {
         type: 'string',
-        description:
-          'Select page by title (partial match, case-insensitive). ' +
-          'Example: "Google" will match "Google Search - About"',
+        description: 'Title substring (case-insensitive)',
       },
     },
     required: [],
@@ -79,13 +70,13 @@ export const selectPageTool = {
 
 export const closePageTool = {
   name: 'close_page',
-  description: 'Close the tab at the given index. Use list_pages to find valid indices.',
+  description: 'Close tab by index.',
   inputSchema: {
     type: 'object',
     properties: {
       pageIdx: {
         type: 'number',
-        description: 'The index of the page to close',
+        description: 'Tab index to close',
       },
     },
     required: ['pageIdx'],

--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -13,8 +13,7 @@ import type { McpToolResponse } from '../types/common.js';
 // Tool definitions
 export const screenshotPageTool = {
   name: 'screenshot_page',
-  description:
-    'Capture a PNG screenshot of the current page and return it as a base64 string (without data: prefix). TIP: Use for visual verification rather than structural inspection.',
+  description: 'Capture page screenshot as base64 PNG.',
   inputSchema: {
     type: 'object',
     properties: {},
@@ -23,14 +22,13 @@ export const screenshotPageTool = {
 
 export const screenshotByUidTool = {
   name: 'screenshot_by_uid',
-  description:
-    'Capture a PNG screenshot of a specific element by UID and return it as a base64 string (without data: prefix). TIP: Take a fresh snapshot if the UID is stale.',
+  description: 'Capture element screenshot by UID as base64 PNG.',
   inputSchema: {
     type: 'object',
     properties: {
       uid: {
         type: 'string',
-        description: 'The UID of the element to screenshot',
+        description: 'Element UID from snapshot',
       },
     },
     required: ['uid'],

--- a/src/tools/script.ts
+++ b/src/tools/script.ts
@@ -7,32 +7,23 @@ import type { McpToolResponse } from '../types/common.js';
 
 export const evaluateScriptTool = {
   name: 'evaluate_script',
-  description:
-    'Execute a JavaScript function in the selected tab and return its JSON-serializable result. Use with caution; prefer snapshot+UID tools for interactions. This tool may be disabled by default.',
+  description: 'Execute JS function in page. Prefer UID tools for interactions.',
   inputSchema: {
     type: 'object',
     properties: {
       function: {
         type: 'string',
-        description: `A JavaScript function to run in the currently selected page.
-Example without arguments: \`() => {
-  return document.title
-}\` or \`async () => {
-  return await fetch("example.com")
-}\`.
-Example with arguments: \`(el) => {
-  return el.innerText;
-}\``,
+        description: 'JS function string, e.g. () => document.title',
       },
       args: {
         type: 'array',
-        description: 'An optional list of arguments to pass to the function (UIDs from snapshot).',
+        description: 'UIDs to pass as function arguments',
         items: {
           type: 'object',
           properties: {
             uid: {
               type: 'string',
-              description: 'The uid of an element on the page from the page content snapshot',
+              description: 'Element UID from snapshot',
             },
           },
           required: ['uid'],
@@ -40,8 +31,7 @@ Example with arguments: \`(el) => {
       },
       timeout: {
         type: 'number',
-        description:
-          'Optional timeout in milliseconds for script execution (default: 5000). Protection against infinite loops.',
+        description: 'Timeout in ms (default: 5000)',
       },
     },
     required: ['function'],

--- a/src/tools/snapshot.ts
+++ b/src/tools/snapshot.ts
@@ -10,26 +10,25 @@ const DEFAULT_SNAPSHOT_LINES = 100;
 // Tool definitions
 export const takeSnapshotTool = {
   name: 'take_snapshot',
-  description:
-    'Capture a textual page snapshot with stable UIDs for elements. Always take a fresh snapshot after navigation or major DOM changes. TIP: Use the UIDs with click_by_uid / fill_by_uid / hover_by_uid. The output may be truncated for readability.',
+  description: 'Capture DOM snapshot with stable UIDs. Retake after navigation.',
   inputSchema: {
     type: 'object',
     properties: {
       maxLines: {
         type: 'number',
-        description: 'Maximum number of lines to return in output (default: 100)',
+        description: 'Max lines (default: 100)',
       },
       includeAttributes: {
         type: 'boolean',
-        description: 'Include detailed ARIA and computed attributes in output (default: false)',
+        description: 'Include ARIA attributes (default: false)',
       },
       includeText: {
         type: 'boolean',
-        description: 'Include text content in output (default: true)',
+        description: 'Include text (default: true)',
       },
       maxDepth: {
         type: 'number',
-        description: 'Maximum depth of tree to include (default: unlimited)',
+        description: 'Max tree depth',
       },
     },
   },
@@ -37,14 +36,13 @@ export const takeSnapshotTool = {
 
 export const resolveUidToSelectorTool = {
   name: 'resolve_uid_to_selector',
-  description:
-    'Resolve a UID to a CSS selector (debugging aid). Fails on stale UIDs—take a fresh snapshot first.',
+  description: 'Resolve UID to CSS selector. Fails if stale.',
   inputSchema: {
     type: 'object',
     properties: {
       uid: {
         type: 'string',
-        description: 'The UID from a snapshot to resolve',
+        description: 'UID from snapshot',
       },
     },
     required: ['uid'],
@@ -53,8 +51,7 @@ export const resolveUidToSelectorTool = {
 
 export const clearSnapshotTool = {
   name: 'clear_snapshot',
-  description:
-    'Clear the snapshot/UID cache. Usually not needed, as navigation invalidates snapshots automatically.',
+  description: 'Clear snapshot cache. Usually not needed.',
   inputSchema: {
     type: 'object',
     properties: {},

--- a/src/tools/utilities.ts
+++ b/src/tools/utilities.ts
@@ -8,14 +8,13 @@ import type { McpToolResponse } from '../types/common.js';
 // Tool definitions - Dialogs
 export const acceptDialogTool = {
   name: 'accept_dialog',
-  description:
-    'Accept the active browser dialog (alert/confirm/prompt). For prompts, you may provide promptText. Returns an error if no dialog is open.',
+  description: 'Accept browser dialog. Provide promptText for prompts.',
   inputSchema: {
     type: 'object',
     properties: {
       promptText: {
         type: 'string',
-        description: 'Text to enter in a prompt dialog (optional, only for prompt dialogs)',
+        description: 'Text for prompt dialogs',
       },
     },
   },
@@ -23,8 +22,7 @@ export const acceptDialogTool = {
 
 export const dismissDialogTool = {
   name: 'dismiss_dialog',
-  description:
-    'Dismiss the active browser dialog (alert/confirm/prompt). Returns an error if no dialog is open.',
+  description: 'Dismiss browser dialog.',
   inputSchema: {
     type: 'object',
     properties: {},
@@ -34,15 +32,14 @@ export const dismissDialogTool = {
 // Tool definitions - History
 export const navigateHistoryTool = {
   name: 'navigate_history',
-  description:
-    "Navigate the selected tab's history back or forward. NOTE: After navigation, UIDs from previous snapshots are stale—take a new snapshot before UID-based actions.",
+  description: 'Navigate history back/forward. UIDs become stale.',
   inputSchema: {
     type: 'object',
     properties: {
       direction: {
         type: 'string',
         enum: ['back', 'forward'],
-        description: 'Direction to navigate in history',
+        description: 'back or forward',
       },
     },
     required: ['direction'],
@@ -52,18 +49,17 @@ export const navigateHistoryTool = {
 // Tool definitions - Viewport
 export const setViewportSizeTool = {
   name: 'set_viewport_size',
-  description:
-    'Set the browser viewport size (width x height in pixels). In some modes (e.g., headless), the actual size may vary slightly.',
+  description: 'Set viewport dimensions in pixels.',
   inputSchema: {
     type: 'object',
     properties: {
       width: {
         type: 'number',
-        description: 'Viewport width in pixels',
+        description: 'Width in pixels',
       },
       height: {
         type: 'number',
-        description: 'Viewport height in pixels',
+        description: 'Height in pixels',
       },
     },
     required: ['width', 'height'],

--- a/tests/tools/script.test.ts
+++ b/tests/tools/script.test.ts
@@ -12,7 +12,7 @@ describe('Script Tools', () => {
     });
 
     it('should have valid description', () => {
-      expect(evaluateScriptTool.description).toContain('JavaScript');
+      expect(evaluateScriptTool.description).toContain('JS');
     });
 
     it('should have valid input schema', () => {


### PR DESCRIPTION
Reduce token consumption by making tool descriptions and parameter descriptions more concise while preserving functionality:

- Remove redundant phrases ("This tool allows you to...", "Use this to...")
- Shorten parameter descriptions while keeping essential info
- Remove inline examples (use short hints instead)
- Apply consistent patterns across similar parameters
- Estimated ~50% reduction in tool definition tokens

Updated test to match shortened JS function description.