### PR TITLE
refactor: optimize MCP response sizes for reduced token consumption

### DIFF
--- a/src/firefox/snapshot/formatter.ts
+++ b/src/firefox/snapshot/formatter.ts
@@ -6,9 +6,9 @@
 import type { SnapshotNode } from './types.js';
 
 /**
- * Max attribute value length
+ * Max attribute value length (aggressive truncation for token efficiency)
  */
-const MAX_ATTR_LENGTH = 50;
+const MAX_ATTR_LENGTH = 30;
 
 /**
  * Formatting options

--- a/src/tools/console.ts
+++ b/src/tools/console.ts
@@ -218,7 +218,7 @@ export async function handleListConsoleMessages(args: unknown): Promise<McpToolR
     }
 
     if (truncated) {
-      output += `\n... ${filteredCount - messages.length} more messages (increase limit to see more)`;
+      output += `\n[+${filteredCount - messages.length} more]`;
     }
 
     return successResponse(output);
@@ -235,10 +235,7 @@ export async function handleClearConsoleMessages(_args: unknown): Promise<McpToo
     const count = (await firefox.getConsoleMessages()).length;
     firefox.clearConsoleMessages();
 
-    return successResponse(
-      `Cleared ${count} console message(s) from buffer.\n\n` +
-        'You can now capture fresh console output from new page activity.'
-    );
+    return successResponse(`✅ cleared ${count} messages`);
   } catch (error) {
     return errorResponse(error as Error);
   }

--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -2,12 +2,7 @@
  * Screenshot tools for visual capture
  */
 
-import {
-  successResponse,
-  errorResponse,
-  TOKEN_LIMITS,
-  estimateTokens,
-} from '../utils/response-helpers.js';
+import { successResponse, errorResponse, TOKEN_LIMITS } from '../utils/response-helpers.js';
 import type { McpToolResponse } from '../types/common.js';
 
 // Tool definitions
@@ -38,31 +33,18 @@ export const screenshotByUidTool = {
 /**
  * Build screenshot response with size safeguards.
  */
-function buildScreenshotResponse(base64Png: string, context: string): McpToolResponse {
+function buildScreenshotResponse(base64Png: string, label: string): McpToolResponse {
   const sizeKB = Math.round(base64Png.length / 1024);
-  const estimatedTokens = estimateTokens(base64Png);
 
   // Check if screenshot exceeds size limit
   if (base64Png.length > TOKEN_LIMITS.MAX_SCREENSHOT_CHARS) {
     const truncatedData = base64Png.slice(0, TOKEN_LIMITS.MAX_SCREENSHOT_CHARS);
-    return successResponse(
-      `📸 ${context} (${sizeKB}KB)\n\n` +
-        `⚠️ Screenshot truncated (~${Math.round(estimatedTokens / 1000)}k tokens exceeds limit)\n` +
-        `Only first ${Math.round(TOKEN_LIMITS.MAX_SCREENSHOT_CHARS / 1024)}KB shown.\n` +
-        `TIP: For full screenshots, use a dedicated screenshot tool or save to file.\n\n` +
-        `Base64 PNG data (truncated):\n${truncatedData}\n\n[...truncated]`
-    );
+    return successResponse(`📸 ${label} (${sizeKB}KB) [truncated]\n${truncatedData}`);
   }
 
-  // Add warning for large but not truncated screenshots
-  let warning = '';
-  if (base64Png.length > TOKEN_LIMITS.WARNING_THRESHOLD_CHARS) {
-    warning = `⚠️ Large screenshot (~${Math.round(estimatedTokens / 1000)}k tokens) - may fill context quickly\n\n`;
-  }
-
-  return successResponse(
-    `📸 ${context} (${sizeKB}KB)\n\n` + warning + `Base64 PNG data:\n${base64Png}`
-  );
+  // Add warning for large screenshots
+  const warn = base64Png.length > TOKEN_LIMITS.WARNING_THRESHOLD_CHARS ? ' [large]' : '';
+  return successResponse(`📸 ${label} (${sizeKB}KB)${warn}\n${base64Png}`);
 }
 
 // Handlers
@@ -73,19 +55,13 @@ export async function handleScreenshotPage(_args: unknown): Promise<McpToolRespo
 
     const base64Png = await firefox.takeScreenshotPage();
 
-    // Validate base64 format
     if (!base64Png || typeof base64Png !== 'string') {
-      throw new Error('Failed to capture screenshot: invalid data returned');
+      throw new Error('Invalid screenshot data');
     }
 
-    return buildScreenshotResponse(base64Png, 'Page screenshot captured');
+    return buildScreenshotResponse(base64Png, 'page');
   } catch (error) {
-    return errorResponse(
-      new Error(
-        `Failed to capture page screenshot: ${(error as Error).message}\n\n` +
-          'The page may not be fully loaded or accessible.'
-      )
-    );
+    return errorResponse(error as Error);
   }
 }
 
@@ -94,7 +70,7 @@ export async function handleScreenshotByUid(args: unknown): Promise<McpToolRespo
     const { uid } = args as { uid: string };
 
     if (!uid || typeof uid !== 'string') {
-      throw new Error('uid parameter is required and must be a string');
+      throw new Error('uid required');
     }
 
     const { getFirefox } = await import('../index.js');
@@ -103,27 +79,22 @@ export async function handleScreenshotByUid(args: unknown): Promise<McpToolRespo
     try {
       const base64Png = await firefox.takeScreenshotByUid(uid);
 
-      // Validate base64 format
       if (!base64Png || typeof base64Png !== 'string') {
-        throw new Error('Failed to capture screenshot: invalid data returned');
+        throw new Error('Invalid screenshot data');
       }
 
-      return buildScreenshotResponse(base64Png, `Element screenshot captured for UID "${uid}"`);
+      return buildScreenshotResponse(base64Png, uid);
     } catch (error) {
       const errorMsg = (error as Error).message;
 
-      // Friendly error for stale UIDs
+      // Concise error for stale UIDs
       if (
         errorMsg.includes('stale') ||
         errorMsg.includes('Snapshot') ||
         errorMsg.includes('UID') ||
         errorMsg.includes('not found')
       ) {
-        throw new Error(
-          `UID "${uid}" is stale or invalid.\n\n` +
-            'The page may have changed since the snapshot was taken.\n' +
-            'Please call take_snapshot to get fresh UIDs and try again.'
-        );
+        throw new Error(`${uid} stale/invalid. Call take_snapshot first.`);
       }
 
       throw error;

--- a/src/tools/utilities.ts
+++ b/src/tools/utilities.ts
@@ -76,21 +76,13 @@ export async function handleAcceptDialog(args: unknown): Promise<McpToolResponse
 
     try {
       await firefox.acceptDialog(promptText);
-      let message = '✅ Dialog accepted';
-      if (promptText) {
-        message += ` with text: "${promptText}"`;
-      }
-      return successResponse(message);
+      return successResponse(promptText ? `✅ Accepted: "${promptText}"` : '✅ Accepted');
     } catch (error) {
       const errorMsg = (error as Error).message;
 
-      // Friendly error for no active dialog
+      // Concise error for no active dialog
       if (errorMsg.includes('no such alert') || errorMsg.includes('No dialog')) {
-        throw new Error(
-          'No active dialog found.\n\n' +
-            'Dialogs must be accepted shortly after they appear. ' +
-            'Make sure a dialog is currently visible on the page.'
-        );
+        throw new Error('No active dialog');
       }
 
       throw error;
@@ -107,17 +99,13 @@ export async function handleDismissDialog(_args: unknown): Promise<McpToolRespon
 
     try {
       await firefox.dismissDialog();
-      return successResponse('✅ Dialog dismissed/cancelled');
+      return successResponse('✅ Dismissed');
     } catch (error) {
       const errorMsg = (error as Error).message;
 
-      // Friendly error for no active dialog
+      // Concise error for no active dialog
       if (errorMsg.includes('no such alert') || errorMsg.includes('No dialog')) {
-        throw new Error(
-          'No active dialog found.\n\n' +
-            'Dialogs must be dismissed shortly after they appear. ' +
-            'Make sure a dialog is currently visible on the page.'
-        );
+        throw new Error('No active dialog');
       }
 
       throw error;
@@ -145,18 +133,9 @@ export async function handleNavigateHistory(args: unknown): Promise<McpToolRespo
       await firefox.navigateForward();
     }
 
-    return successResponse(
-      `✅ Navigated ${direction} in history\n\n` +
-        '⚠️  UIDs from previous snapshots are now stale. ' +
-        'Call take_snapshot before using UID-based actions.'
-    );
+    return successResponse(`✅ ${direction}`);
   } catch (error) {
-    return errorResponse(
-      new Error(
-        `Failed to navigate ${(args as { direction: string }).direction || 'in history'}: ${(error as Error).message}\n\n` +
-          'The page may not have history in this direction available.'
-      )
-    );
+    return errorResponse(error as Error);
   }
 }
 
@@ -178,16 +157,8 @@ export async function handleSetViewportSize(args: unknown): Promise<McpToolRespo
 
     await firefox.setViewportSize(width, height);
 
-    return successResponse(
-      `✅ Viewport size set to ${width}x${height} pixels\n\n` +
-        'NOTE: Actual viewport may differ slightly in some browser modes (e.g., headless).'
-    );
+    return successResponse(`✅ ${width}x${height}`);
   } catch (error) {
-    return errorResponse(
-      new Error(
-        `Failed to set viewport size: ${(error as Error).message}\n\n` +
-          'Some browser configurations may not support precise viewport sizing.'
-      )
-    );
+    return errorResponse(error as Error);
   }
 }


### PR DESCRIPTION
- Remove verbose 'HOW TO USE THIS SNAPSHOT' instructional text
- Minimize success messages (e.g., "✅ 1200x800" instead of verbose notes)
- Reduce MAX_ATTR_LENGTH from 50 to 30 chars for more aggressive truncation
- Simplify error messages throughout all tools
- Compact page list and network request output formatting
- Remove redundant explanatory text from responses

Token savings from reduced response verbosity helps preserve LLM context.