### PR TITLE
feat: add --connect-existing mode to attach to running Firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ claude mcp add firefox-devtools npx firefox-devtools-mcp@latest \
 Option B — Edit Claude Code settings JSON
 
 Add to your Claude Code config file:
+
 - macOS: `~/Library/Application Support/Claude/Code/mcp_settings.json`
 - Linux: `~/.config/claude/code/mcp_settings.json`
 - Windows: `%APPDATA%\Claude\Code\mcp_settings.json`
@@ -75,6 +76,7 @@ npx @modelcontextprotocol/inspector npx firefox-devtools-mcp@latest --start-url 
 ```
 
 Then call tools like:
+
 - `list_pages`, `select_page`, `navigate_page`
 - `take_snapshot` then `click_by_uid` / `fill_by_uid`
 - `list_network_requests` (always‑on capture), `get_network_request`
@@ -91,6 +93,30 @@ You can pass flags or environment variables (names on the right):
 - `--firefox-arg` — extra Firefox arguments (repeatable)
 - `--start-url` — open this URL on start (`START_URL`)
 - `--accept-insecure-certs` — ignore TLS errors (`ACCEPT_INSECURE_CERTS=true`)
+- `--connect-existing` — attach to an already-running Firefox instead of launching a new one (`CONNECT_EXISTING=true`)
+- `--marionette-port` — Marionette port for connect-existing mode, default 2828 (`MARIONETTE_PORT`)
+
+### Connect to existing Firefox
+
+Use `--connect-existing` to automate your real browsing session — with cookies, logins, and open tabs intact:
+
+```bash
+# Start Firefox with Marionette enabled
+firefox --marionette
+
+# Run the MCP server
+npx firefox-devtools-mcp --connect-existing --marionette-port 2828
+```
+
+Or set `marionette.enabled` to `true` in `about:config` (or `user.js`) to enable Marionette on every launch.
+
+BiDi-dependent features (console events, network events) are not available in connect-existing mode; all other features work normally.
+
+> **Warning:** Do not leave Marionette enabled during normal browsing. It sets
+> `navigator.webdriver = true` and changes other browser fingerprint signals,
+> which can trigger bot detection on sites protected by Cloudflare, Akamai, etc.
+> Only enable Marionette when you need MCP automation, then restart Firefox
+> normally afterward.
 
 ## Tool overview
 
@@ -134,6 +160,7 @@ npm run inspector:dev
 - Stale UIDs after navigation: take a fresh snapshot (`take_snapshot`) before using UID tools.
 - Windows 10: Error during discovery for MCP server 'firefox-devtools': MCP error -32000: Connection closed
   - **Solution 1** Call using `cmd` (For more info https://github.com/modelcontextprotocol/servers/issues/1082#issuecomment-2791786310)
+
     ```json
     "mcpServers": {
       "firefox-devtools": {
@@ -141,10 +168,12 @@ npm run inspector:dev
         "args": ["/c", "npx", "-y", "firefox-devtools-mcp@latest"]
       }
     }
-    ``` 
+    ```
+
     > **The Key Change:** On Windows, running a Node.js package via `npx` often requires the `cmd /c` prefix to be executed correctly from within another process like VSCode's extension host. Therefore, `"command": "npx"` was replaced with `"command": "cmd"`, and the actual `npx` command was moved into the `"args"` array, preceded by `"/c"`. This fix allows Windows to interpret the command correctly and launch the server.
   
   - **Solution 2** Instead of another layer of shell you can write the absolute path to `npx`:
+
     ```json
     "mcpServers": {
       "firefox-devtools": {
@@ -153,6 +182,7 @@ npm run inspector:dev
       }
     }
     ```
+
     Note: The path above is an example. You must adjust it to match the actual location of `npx` on your machine. Depending on your setup, the file extension might be `.cmd`, `.bat`, or `.exe` rather than `.ps1`. Also, ensure you use double backslashes (`\\`) as path delimiters, as required by the JSON format.
 
 ## Versioning

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -55,6 +55,17 @@ export const cliOptions = {
     description: 'URL to open when Firefox starts (default: about:home)',
     default: process.env.START_URL ?? 'about:home',
   },
+  connectExisting: {
+    type: 'boolean',
+    description:
+      'Connect to an already-running Firefox instance via Marionette instead of launching a new one. Requires Firefox to be running with marionette.enabled=true (set in user.js or launched with --marionette).',
+    default: (process.env.CONNECT_EXISTING ?? 'false') === 'true',
+  },
+  marionettePort: {
+    type: 'number',
+    description: 'Marionette port to connect to when using --connect-existing (default: 2828)',
+    default: Number(process.env.MARIONETTE_PORT ?? '2828'),
+  },
 } satisfies Record<string, YargsOptions>;
 
 export function parseArguments(version: string, argv = process.argv) {

--- a/src/firefox/core.ts
+++ b/src/firefox/core.ts
@@ -2,68 +2,532 @@
  * Core WebDriver + BiDi connection management
  */
 
-import { Builder, Browser, WebDriver } from 'selenium-webdriver';
+import { Builder, Browser } from 'selenium-webdriver';
 import firefox from 'selenium-webdriver/firefox.js';
+import { spawn, type ChildProcess } from 'node:child_process';
 import type { FirefoxLaunchOptions } from './types.js';
 import { log, logDebug } from '../utils/logger.js';
 
+// ---------------------------------------------------------------------------
+// Shared driver interface — the minimal surface used by all consumers
+// (DomInteractions, PageManagement, SnapshotManager, UidResolver).
+// Both selenium WebDriver and GeckodriverHttpDriver satisfy this contract.
+// ---------------------------------------------------------------------------
+
+export interface IElement {
+  click(): Promise<void>;
+  clear(): Promise<void>;
+  sendKeys(...args: Array<string | number>): Promise<void>;
+  isDisplayed(): Promise<boolean>;
+  takeScreenshot(): Promise<string>;
+}
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export interface IDriver {
+  getTitle(): Promise<string>;
+  getCurrentUrl(): Promise<string>;
+  getWindowHandle(): Promise<string>;
+  getAllWindowHandles(): Promise<string[]>;
+  get(url: string): Promise<void>;
+  getPageSource(): Promise<string>;
+  executeScript<T>(script: string | ((...a: any[]) => any), ...args: unknown[]): Promise<T>;
+  executeAsyncScript<T>(script: string | ((...a: any[]) => any), ...args: unknown[]): Promise<T>;
+  takeScreenshot(): Promise<string>;
+  close(): Promise<void>;
+  findElement(locator: any): Promise<IElement>;
+  switchTo(): {
+    window(handle: string): Promise<void>;
+    newWindow(type: string): Promise<{ handle: string }>;
+    alert(): Promise<{
+      accept(): Promise<void>;
+      dismiss(): Promise<void>;
+      getText(): Promise<string>;
+      sendKeys(text: string): Promise<void>;
+    }>;
+  };
+  navigate(): {
+    back(): Promise<void>;
+    forward(): Promise<void>;
+    refresh(): Promise<void>;
+  };
+  manage(): {
+    window(): {
+      setRect(rect: { width: number; height: number }): Promise<void>;
+    };
+  };
+  actions(opts?: { async?: boolean }): {
+    move(opts: { x?: number; y?: number; origin?: unknown }): any;
+    click(): any;
+    doubleClick(el?: unknown): any;
+    perform(): Promise<void>;
+    clear(): Promise<void>;
+  };
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+// ---------------------------------------------------------------------------
+// GeckodriverElement — wraps a raw WebDriver element reference for HTTP API
+// ---------------------------------------------------------------------------
+
+class GeckodriverElement implements IElement {
+  constructor(
+    private cmd: (method: string, path: string, body?: unknown) => Promise<unknown>,
+    private elementId: string
+  ) {}
+
+  async click(): Promise<void> {
+    await this.cmd('POST', `/element/${this.elementId}/click`, {});
+  }
+
+  async clear(): Promise<void> {
+    await this.cmd('POST', `/element/${this.elementId}/clear`, {});
+  }
+
+  async sendKeys(...args: Array<string | number>): Promise<void> {
+    const text = args.join('');
+    await this.cmd('POST', `/element/${this.elementId}/value`, { text });
+  }
+
+  async isDisplayed(): Promise<boolean> {
+    return (await this.cmd('GET', `/element/${this.elementId}/displayed`)) as boolean;
+  }
+
+  async takeScreenshot(): Promise<string> {
+    return (await this.cmd('GET', `/element/${this.elementId}/screenshot`)) as string;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// GeckodriverHttpDriver
+// ---------------------------------------------------------------------------
+
+/**
+ * Thin wrapper around geckodriver HTTP API that implements the subset of
+ * WebDriver interface used by firefox-devtools-mcp.
+ *
+ * This exists because selenium-webdriver's Driver.createSession() tries to
+ * auto-upgrade to BiDi WebSocket, which hangs when connecting to an existing
+ * Firefox instance. By talking directly to geckodriver's HTTP API we avoid
+ * the BiDi issue entirely.
+ */
+class GeckodriverHttpDriver implements IDriver {
+  private baseUrl: string;
+  private sessionId: string;
+  private gdProcess: ChildProcess;
+
+  constructor(baseUrl: string, sessionId: string, gdProcess: ChildProcess) {
+    this.baseUrl = baseUrl;
+    this.sessionId = sessionId;
+    this.gdProcess = gdProcess;
+  }
+
+  static async connect(marionettePort: number): Promise<GeckodriverHttpDriver> {
+    // Find geckodriver binary via selenium-manager
+    const path = await import('node:path');
+    const { execFileSync } = await import('node:child_process');
+
+    let geckodriverPath: string;
+    try {
+      // selenium-manager ships with selenium-webdriver and resolves/downloads geckodriver
+      const { createRequire } = await import('node:module');
+      const require = createRequire(import.meta.url);
+      const swPkg = require.resolve('selenium-webdriver/package.json');
+      const swDir = path.dirname(swPkg);
+      const platform =
+        process.platform === 'win32'
+          ? 'windows'
+          : process.platform === 'darwin'
+            ? 'macos'
+            : 'linux';
+      const ext = process.platform === 'win32' ? '.exe' : '';
+      const smBin = path.join(swDir, 'bin', platform, `selenium-manager${ext}`);
+      const result = JSON.parse(
+        execFileSync(smBin, ['--browser', 'firefox', '--output', 'json'], { encoding: 'utf-8' })
+      );
+      geckodriverPath = result.result.driver_path;
+    } catch {
+      // Fallback: walk the selenium cache directory to find any geckodriver binary
+      const os = await import('node:os');
+      const fs = await import('node:fs');
+      const cacheBase = path.join(os.homedir(), '.cache/selenium/geckodriver');
+      geckodriverPath = findGeckodriverInCache(fs, path, cacheBase);
+      if (!geckodriverPath) {
+        throw new Error('Cannot find geckodriver binary. Ensure selenium-webdriver is installed.');
+      }
+    }
+    logDebug(`Using geckodriver: ${geckodriverPath}`);
+
+    // Use --port=0 to let the OS assign a free port atomically (geckodriver ≥0.34.0)
+    const gd = spawn(
+      geckodriverPath,
+      ['--connect-existing', '--marionette-port', String(marionettePort), '--port', '0'],
+      { stdio: ['ignore', 'pipe', 'pipe'] }
+    );
+
+    // Wait for geckodriver to start listening and extract the assigned port
+    const port = await new Promise<number>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('Geckodriver startup timeout')), 10000);
+      const onData = (data: Buffer) => {
+        const msg = data.toString();
+        logDebug(`[geckodriver] ${msg.trim()}`);
+        const match = msg.match(/Listening on\s+\S+:(\d+)/);
+        if (match?.[1]) {
+          clearTimeout(timeout);
+          resolve(parseInt(match[1], 10));
+        }
+      };
+      // Listen on both stdout and stderr — geckodriver's output stream varies by version/platform
+      gd.stdout?.on('data', onData);
+      gd.stderr?.on('data', onData);
+      gd.on('error', (err) => {
+        clearTimeout(timeout);
+        reject(err);
+      });
+      gd.on('exit', (code) => {
+        clearTimeout(timeout);
+        reject(new Error(`Geckodriver exited with code ${code}`));
+      });
+    });
+
+    const baseUrl = `http://127.0.0.1:${port}`;
+
+    // Create a WebDriver session
+    const resp = await fetch(`${baseUrl}/session`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ capabilities: { alwaysMatch: {} } }),
+    });
+    const json = (await resp.json()) as {
+      value: { sessionId: string; capabilities: Record<string, unknown> };
+    };
+    if (!json.value?.sessionId) {
+      throw new Error(`Failed to create session: ${JSON.stringify(json)}`);
+    }
+
+    return new GeckodriverHttpDriver(baseUrl, json.value.sessionId, gd);
+  }
+
+  private async cmd(method: string, path: string, body?: unknown): Promise<unknown> {
+    const url = `${this.baseUrl}/session/${this.sessionId}${path}`;
+    const opts: RequestInit = {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+    };
+    if (body !== undefined) {
+      opts.body = JSON.stringify(body);
+    }
+    const resp = await fetch(url, opts);
+    const json = (await resp.json()) as { value: unknown };
+    if (json.value && typeof json.value === 'object' && 'error' in json.value) {
+      const err = json.value as Record<string, string>;
+      throw new Error(`${err.error}: ${err.message}`);
+    }
+    return json.value;
+  }
+
+  // WebDriver-compatible methods used by the rest of the codebase
+  async getTitle(): Promise<string> {
+    return (await this.cmd('GET', '/title')) as string;
+  }
+  async getCurrentUrl(): Promise<string> {
+    return (await this.cmd('GET', '/url')) as string;
+  }
+  async getWindowHandle(): Promise<string> {
+    return (await this.cmd('GET', '/window')) as string;
+  }
+  async getAllWindowHandles(): Promise<string[]> {
+    return (await this.cmd('GET', '/window/handles')) as string[];
+  }
+  async get(url: string): Promise<void> {
+    await this.cmd('POST', '/url', { url });
+  }
+  async getPageSource(): Promise<string> {
+    return (await this.cmd('GET', '/source')) as string;
+  }
+  async executeScript<T>(script: string, ...args: unknown[]): Promise<T> {
+    return (await this.cmd('POST', '/execute/sync', { script, args })) as T;
+  }
+  async executeAsyncScript<T>(script: string, ...args: unknown[]): Promise<T> {
+    return (await this.cmd('POST', '/execute/async', { script, args })) as T;
+  }
+  async takeScreenshot(): Promise<string> {
+    return (await this.cmd('GET', '/screenshot')) as string;
+  }
+  async close(): Promise<void> {
+    await this.cmd('DELETE', '/window');
+  }
+  async getSession(): Promise<{ getId(): string }> {
+    return { getId: () => this.sessionId };
+  }
+
+  // Element finding
+  async findElement(locator: Record<string, unknown>): Promise<GeckodriverElement> {
+    // Accept selenium By objects (which have using/value) and raw {using, value} objects
+    const loc = locator as { using?: string; value?: string };
+    const using = loc.using ?? 'css selector';
+    const value = loc.value ?? '';
+    const result = (await this.cmd('POST', '/element', { using, value })) as Record<string, string>;
+    // WebDriver protocol returns { "element-xxx": "id" } or { ELEMENT: "id" }
+    const elementId = Object.values(result)[0]!;
+    return new GeckodriverElement(this.cmd.bind(this), elementId);
+  }
+
+  async findElements(locator: Record<string, unknown>): Promise<GeckodriverElement[]> {
+    const loc = locator as { using?: string; value?: string };
+    const using = loc.using ?? 'css selector';
+    const value = loc.value ?? '';
+    const results = (await this.cmd('POST', '/elements', { using, value })) as Array<
+      Record<string, string>
+    >;
+    return results.map((r) => new GeckodriverElement(this.cmd.bind(this), Object.values(r)[0]!));
+  }
+
+  // Polling wait — compatible with selenium's Condition objects and plain functions.
+  // Used by dom.ts helpers for element location and visibility polling.
+  async wait<T>(
+    condition:
+      | { fn: (driver: any) => T | Promise<T | null> | null }
+      | ((driver: any) => T | Promise<T | null> | null),
+    timeout = 5000
+  ): Promise<T> {
+    const fn = typeof condition === 'function' ? condition : condition.fn;
+    const deadline = Date.now() + timeout;
+    let lastError: Error | undefined;
+    while (Date.now() < deadline) {
+      try {
+        const result = await fn(this);
+        if (result) {
+          return result;
+        }
+      } catch (e) {
+        lastError = e instanceof Error ? e : new Error(String(e));
+      }
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    throw lastError ?? new Error(`wait() timed out after ${timeout}ms`);
+  }
+
+  switchTo() {
+    return {
+      window: async (handle: string): Promise<void> => {
+        await this.cmd('POST', '/window', { handle });
+      },
+      newWindow: async (type: string): Promise<{ handle: string }> => {
+        return (await this.cmd('POST', '/window/new', { type })) as { handle: string };
+      },
+      alert: async () => {
+        return {
+          accept: async (): Promise<void> => {
+            await this.cmd('POST', '/alert/accept');
+          },
+          dismiss: async (): Promise<void> => {
+            await this.cmd('POST', '/alert/dismiss');
+          },
+          getText: async (): Promise<string> => {
+            return (await this.cmd('GET', '/alert/text')) as string;
+          },
+          sendKeys: async (text: string): Promise<void> => {
+            await this.cmd('POST', '/alert/text', { text });
+          },
+        };
+      },
+    };
+  }
+
+  navigate() {
+    return {
+      back: async (): Promise<void> => {
+        await this.cmd('POST', '/back');
+      },
+      forward: async (): Promise<void> => {
+        await this.cmd('POST', '/forward');
+      },
+      refresh: async (): Promise<void> => {
+        await this.cmd('POST', '/refresh');
+      },
+    };
+  }
+
+  manage() {
+    return {
+      window: () => {
+        return {
+          setRect: async (rect: { width: number; height: number }): Promise<void> => {
+            await this.cmd('POST', '/window/rect', rect);
+          },
+        };
+      },
+    };
+  }
+
+  actions(_opts?: { async?: boolean }) {
+    // Accumulate action sequences for the W3C Actions API
+    const actionSequences: unknown[] = [];
+    const builder = {
+      move: (opts: { x?: number; y?: number; origin?: unknown }) => {
+        actionSequences.push({
+          type: 'pointer',
+          id: 'mouse',
+          parameters: { pointerType: 'mouse' },
+          actions: [{ type: 'pointerMove', ...opts }],
+        });
+        return builder;
+      },
+      click: () => {
+        const last = actionSequences[actionSequences.length - 1] as
+          | { actions: unknown[] }
+          | undefined;
+        if (last) {
+          last.actions.push({ type: 'pointerDown', button: 0 }, { type: 'pointerUp', button: 0 });
+        }
+        return builder;
+      },
+      doubleClick: (_el?: unknown) => {
+        const last = actionSequences[actionSequences.length - 1] as
+          | { actions: unknown[] }
+          | undefined;
+        if (last) {
+          last.actions.push(
+            { type: 'pointerDown', button: 0 },
+            { type: 'pointerUp', button: 0 },
+            { type: 'pointerDown', button: 0 },
+            { type: 'pointerUp', button: 0 }
+          );
+        }
+        return builder;
+      },
+      perform: async (): Promise<void> => {
+        await this.cmd('POST', '/actions', { actions: actionSequences });
+      },
+      clear: async (): Promise<void> => {
+        await this.cmd('DELETE', '/actions');
+      },
+    };
+    return builder;
+  }
+
+  async quit(): Promise<void> {
+    try {
+      await this.cmd('DELETE', '');
+    } catch {
+      // ignore
+    }
+    this.gdProcess.kill();
+  }
+
+  /** Kill the geckodriver process without closing Firefox */
+  kill(): void {
+    this.gdProcess.kill();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Geckodriver cache walker — finds any geckodriver binary cross-platform
+// ---------------------------------------------------------------------------
+
+function findGeckodriverInCache(
+  fs: typeof import('node:fs'),
+  path: typeof import('node:path'),
+  cacheBase: string
+): string {
+  const ext = process.platform === 'win32' ? '.exe' : '';
+  const binaryName = `geckodriver${ext}`;
+
+  try {
+    if (!fs.existsSync(cacheBase)) {
+      return '';
+    }
+
+    // Walk: cacheBase/<platform>/<version>/geckodriver[.exe]
+    for (const platformDir of fs.readdirSync(cacheBase)) {
+      const platformPath = path.join(cacheBase, platformDir);
+      if (!fs.statSync(platformPath).isDirectory()) {
+        continue;
+      }
+
+      // Sort version dirs descending so we prefer the newest
+      const versionDirs = fs.readdirSync(platformPath).sort().reverse();
+      for (const versionDir of versionDirs) {
+        const candidate = path.join(platformPath, versionDir, binaryName);
+        if (fs.existsSync(candidate)) {
+          return candidate;
+        }
+      }
+    }
+  } catch {
+    // Ignore permission errors etc.
+  }
+  return '';
+}
+
 export class FirefoxCore {
-  private driver: WebDriver | null = null;
+  private driver: IDriver | null = null;
   private currentContextId: string | null = null;
 
   constructor(private options: FirefoxLaunchOptions) {}
 
   /**
-   * Launch Firefox and establish BiDi connection
+   * Launch Firefox (or connect to an existing instance) and establish BiDi connection
    */
   async connect(): Promise<void> {
-    log('🚀 Launching Firefox via Selenium WebDriver BiDi...');
-
-    // Configure Firefox options
-    const firefoxOptions = new firefox.Options();
-    firefoxOptions.enableBidi();
-
-    if (this.options.headless) {
-      firefoxOptions.addArguments('-headless');
+    if (this.options.connectExisting) {
+      log('🔗 Connecting to existing Firefox via Marionette...');
+    } else {
+      log('🚀 Launching Firefox via Selenium WebDriver BiDi...');
     }
 
-    if (this.options.viewport) {
-      firefoxOptions.windowSize({
-        width: this.options.viewport.width,
-        height: this.options.viewport.height,
-      });
+    if (this.options.connectExisting) {
+      // Connect to existing Firefox via geckodriver HTTP API directly.
+      // We bypass selenium-webdriver because its BiDi auto-upgrade hangs
+      // when used with geckodriver's --connect-existing mode.
+      const port = this.options.marionettePort ?? 2828;
+      this.driver = await GeckodriverHttpDriver.connect(port);
+    } else {
+      // Standard path: launch a new Firefox via selenium-webdriver
+      const firefoxOptions = new firefox.Options();
+      firefoxOptions.enableBidi();
+
+      if (this.options.headless) {
+        firefoxOptions.addArguments('-headless');
+      }
+      if (this.options.viewport) {
+        firefoxOptions.windowSize({
+          width: this.options.viewport.width,
+          height: this.options.viewport.height,
+        });
+      }
+      if (this.options.firefoxPath) {
+        firefoxOptions.setBinary(this.options.firefoxPath);
+      }
+      if (this.options.args && this.options.args.length > 0) {
+        firefoxOptions.addArguments(...this.options.args);
+      }
+      if (this.options.profilePath) {
+        firefoxOptions.setProfile(this.options.profilePath);
+      }
+      if (this.options.acceptInsecureCerts) {
+        firefoxOptions.setAcceptInsecureCerts(true);
+      }
+
+      // selenium WebDriver satisfies IDriver structurally at runtime
+      this.driver = (await new Builder()
+        .forBrowser(Browser.FIREFOX)
+        .setFirefoxOptions(firefoxOptions)
+        .build()) as unknown as IDriver;
     }
 
-    if (this.options.firefoxPath) {
-      firefoxOptions.setBinary(this.options.firefoxPath);
-    }
-
-    if (this.options.args && this.options.args.length > 0) {
-      firefoxOptions.addArguments(...this.options.args);
-    }
-
-    if (this.options.profilePath) {
-      firefoxOptions.setProfile(this.options.profilePath);
-    }
-
-    if (this.options.acceptInsecureCerts) {
-      firefoxOptions.setAcceptInsecureCerts(true);
-    }
-
-    // Build WebDriver instance
-    this.driver = await new Builder()
-      .forBrowser(Browser.FIREFOX)
-      .setFirefoxOptions(firefoxOptions)
-      .build();
-
-    log('✅ Firefox launched with BiDi');
+    log(
+      this.options.connectExisting
+        ? '✅ Connected to existing Firefox'
+        : '✅ Firefox launched with BiDi'
+    );
 
     // Remember current window handle (browsing context)
     this.currentContextId = await this.driver.getWindowHandle();
     logDebug(`Browsing context ID: ${this.currentContextId}`);
 
-    // Navigate if startUrl provided
-    if (this.options.startUrl) {
+    // Navigate if startUrl provided (skip for connectExisting to not disrupt the user's browsing)
+    if (this.options.startUrl && !this.options.connectExisting) {
       await this.driver.get(this.options.startUrl);
       logDebug(`Navigated to: ${this.options.startUrl}`);
     }
@@ -72,9 +536,9 @@ export class FirefoxCore {
   }
 
   /**
-   * Get WebDriver instance (throw if not connected)
+   * Get driver instance (throw if not connected)
    */
-  getDriver(): WebDriver {
+  getDriver(): IDriver {
     if (!this.driver) {
       throw new Error('Driver not connected');
     }
@@ -91,11 +555,9 @@ export class FirefoxCore {
     }
 
     try {
-      // Try a simple command to check if Firefox is responsive
       await this.driver.getWindowHandle();
       return true;
     } catch (error) {
-      // Any error means connection is broken
       logDebug('Connection check failed: Firefox is not responsive');
       return false;
     }
@@ -105,6 +567,9 @@ export class FirefoxCore {
    * Reset driver state (used when Firefox is detected as closed)
    */
   reset(): void {
+    if (this.driver && this.options.connectExisting && 'kill' in this.driver) {
+      (this.driver as { kill(): void }).kill();
+    }
     this.driver = null;
     this.currentContextId = null;
     logDebug('Driver state reset');
@@ -125,11 +590,17 @@ export class FirefoxCore {
   }
 
   /**
-   * Close driver and cleanup
+   * Close driver and cleanup.
+   * When connected to an existing Firefox instance, only kills geckodriver
+   * without closing the browser.
    */
   async close(): Promise<void> {
     if (this.driver) {
-      await this.driver.quit();
+      if (this.options.connectExisting && 'kill' in this.driver) {
+        (this.driver as { kill(): void }).kill();
+      } else if ('quit' in this.driver) {
+        await (this.driver as { quit(): Promise<void> }).quit();
+      }
       this.driver = null;
     }
     log('✅ Firefox DevTools closed');

--- a/src/firefox/dom.ts
+++ b/src/firefox/dom.ts
@@ -2,12 +2,13 @@
  * DOM interactions: evaluate, element lookup, input actions
  */
 
-import { By, Key, until, type WebDriver, type WebElement } from 'selenium-webdriver';
+import { Key } from 'selenium-webdriver';
+import type { IDriver, IElement } from './core.js';
 
 export class DomInteractions {
   constructor(
-    private driver: WebDriver,
-    private resolveUid?: (uid: string) => Promise<WebElement>
+    private driver: IDriver,
+    private resolveUid?: (uid: string) => Promise<IElement>
   ) {}
 
   /**
@@ -25,12 +26,55 @@ export class DomInteractions {
     return String(html);
   }
 
+  // ============================================================================
+  // Element polling helpers (work with both WebDriver and GeckodriverHttpDriver)
+  // ============================================================================
+
+  /**
+   * Poll for an element matching a CSS selector until found or timeout.
+   */
+  private async waitForElement(selector: string, timeout = 5000): Promise<IElement> {
+    const deadline = Date.now() + timeout;
+    let lastError: Error | undefined;
+    while (Date.now() < deadline) {
+      try {
+        return await this.driver.findElement({ using: 'css selector', value: selector });
+      } catch (e) {
+        lastError = e instanceof Error ? e : new Error(String(e));
+      }
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    throw lastError ?? new Error(`Element not found: ${selector}`);
+  }
+
+  /**
+   * Wait until an element reports isDisplayed(), ignoring failures.
+   */
+  private async waitForVisible(el: IElement, timeout = 5000): Promise<void> {
+    const deadline = Date.now() + timeout;
+    while (Date.now() < deadline) {
+      try {
+        if (await el.isDisplayed()) {
+          return;
+        }
+      } catch {
+        // Element may not be ready yet
+      }
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    // Visibility wait is best-effort; don't throw
+  }
+
+  // ============================================================================
+  // Selector-based input methods
+  // ============================================================================
+
   /**
    * Click element by CSS selector
    */
   async clickBySelector(selector: string): Promise<void> {
-    const el = await this.driver.wait(until.elementLocated(By.css(selector)), 5000);
-    await this.driver.wait(until.elementIsVisible(el), 5000).catch(() => {});
+    const el = await this.waitForElement(selector, 5000);
+    await this.waitForVisible(el, 5000);
     await el.click();
   }
 
@@ -38,7 +82,7 @@ export class DomInteractions {
    * Hover over element by CSS selector
    */
   async hoverBySelector(selector: string): Promise<void> {
-    const el = await this.driver.wait(until.elementLocated(By.css(selector)), 5000);
+    const el = await this.waitForElement(selector, 5000);
     await this.driver.actions({ async: true }).move({ origin: el }).perform();
   }
 
@@ -46,7 +90,7 @@ export class DomInteractions {
    * Fill input field by CSS selector
    */
   async fillBySelector(selector: string, text: string): Promise<void> {
-    const el = await this.driver.wait(until.elementLocated(By.css(selector)), 5000);
+    const el = await this.waitForElement(selector, 5000);
     try {
       await el.clear();
     } catch {
@@ -62,30 +106,22 @@ export class DomInteractions {
    */
   async dragAndDropBySelectors(sourceSelector: string, targetSelector: string): Promise<void> {
     await this.driver.executeScript(
-      (srcSel: string, tgtSel: string) => {
-        const src = document.querySelector(srcSel);
-        const tgt = document.querySelector(tgtSel);
-        if (!src || !tgt) {
-          throw new Error('dragAndDrop: element not found');
-        }
-
-        function dispatch(type: string, target: Element, dataTransfer?: DataTransfer) {
-          const evt = new DragEvent(type, {
-            bubbles: true,
-            cancelable: true,
-            dataTransfer,
-          } as DragEventInit);
-          return target.dispatchEvent(evt);
-        }
-
-        // Create DataTransfer if available
-        const dt = typeof DataTransfer !== 'undefined' ? new DataTransfer() : undefined;
-        dispatch('dragstart', src, dt);
-        dispatch('dragenter', tgt, dt);
-        dispatch('dragover', tgt, dt);
-        dispatch('drop', tgt, dt);
-        dispatch('dragend', src, dt);
-      },
+      `
+      var srcSel = arguments[0], tgtSel = arguments[1];
+      var src = document.querySelector(srcSel);
+      var tgt = document.querySelector(tgtSel);
+      if (!src || !tgt) throw new Error('dragAndDrop: element not found');
+      function dispatch(type, target, dt) {
+        var evt = new DragEvent(type, { bubbles: true, cancelable: true, dataTransfer: dt });
+        return target.dispatchEvent(evt);
+      }
+      var dt = typeof DataTransfer !== 'undefined' ? new DataTransfer() : undefined;
+      dispatch('dragstart', src, dt);
+      dispatch('dragenter', tgt, dt);
+      dispatch('dragover', tgt, dt);
+      dispatch('drop', tgt, dt);
+      dispatch('dragend', src, dt);
+    `,
       sourceSelector,
       targetSelector
     );
@@ -95,29 +131,25 @@ export class DomInteractions {
    * File upload: unhide if needed, then send local path to <input type=file>.
    */
   async uploadFileBySelector(selector: string, filePath: string): Promise<void> {
-    // Try to locate input element
-    const el = await this.driver.wait(until.elementLocated(By.css(selector)), 5000);
+    const el = await this.waitForElement(selector, 5000);
     // Ensure it's an <input type=file>; if hidden, unhide via JS
-    await this.driver.executeScript((sel: string) => {
-      const e = document.querySelector(sel);
-      if (!e) {
-        throw new Error('uploadFile: element not found');
-      }
-      if (e.tagName !== 'INPUT' || (e as HTMLInputElement).type !== 'file') {
+    await this.driver.executeScript(
+      `
+      var sel = arguments[0];
+      var e = document.querySelector(sel);
+      if (!e) throw new Error('uploadFile: element not found');
+      if (e.tagName !== 'INPUT' || e.type !== 'file')
         throw new Error('uploadFile: selector must target <input type=file>');
-      }
-      const style = window.getComputedStyle(e);
+      var style = window.getComputedStyle(e);
       if (style.display === 'none' || style.visibility === 'hidden' || style.opacity === '0') {
-        const s = (e as HTMLElement).style;
-        s.display = 'block';
-        s.visibility = 'visible';
-        s.opacity = '1';
-        s.position = 'fixed';
-        s.left = '0px';
-        s.top = '0px';
+        var s = e.style;
+        s.display = 'block'; s.visibility = 'visible'; s.opacity = '1';
+        s.position = 'fixed'; s.left = '0px'; s.top = '0px';
         s.zIndex = '2147483647';
       }
-    }, selector);
+    `,
+      selector
+    );
     await el.sendKeys(filePath);
   }
 
@@ -134,7 +166,7 @@ export class DomInteractions {
       throw new Error('clickByUid: resolveUid callback not set. Ensure snapshot is initialized.');
     }
     const el = await this.resolveUid(uid);
-    await this.driver.wait(until.elementIsVisible(el), 5000).catch(() => {});
+    await this.waitForVisible(el, 5000);
 
     if (dblClick) {
       await this.driver.actions({ async: true }).doubleClick(el).perform();
@@ -198,28 +230,20 @@ export class DomInteractions {
 
     // Use JS drag events fallback for compatibility (Actions DnD not used)
     await this.driver.executeScript(
-      (srcEl: Element, tgtEl: Element) => {
-        if (!srcEl || !tgtEl) {
-          throw new Error('dragAndDrop: element not found');
-        }
-
-        function dispatch(type: string, target: Element, dataTransfer?: DataTransfer) {
-          const evt = new DragEvent(type, {
-            bubbles: true,
-            cancelable: true,
-            dataTransfer,
-          } as DragEventInit);
-          return target.dispatchEvent(evt);
-        }
-
-        // Create DataTransfer if available
-        const dt = typeof DataTransfer !== 'undefined' ? new DataTransfer() : undefined;
-        dispatch('dragstart', srcEl, dt);
-        dispatch('dragenter', tgtEl, dt);
-        dispatch('dragover', tgtEl, dt);
-        dispatch('drop', tgtEl, dt);
-        dispatch('dragend', srcEl, dt);
-      },
+      `
+      var srcEl = arguments[0], tgtEl = arguments[1];
+      if (!srcEl || !tgtEl) throw new Error('dragAndDrop: element not found');
+      function dispatch(type, target, dt) {
+        var evt = new DragEvent(type, { bubbles: true, cancelable: true, dataTransfer: dt });
+        return target.dispatchEvent(evt);
+      }
+      var dt = typeof DataTransfer !== 'undefined' ? new DataTransfer() : undefined;
+      dispatch('dragstart', srcEl, dt);
+      dispatch('dragenter', tgtEl, dt);
+      dispatch('dragover', tgtEl, dt);
+      dispatch('drop', tgtEl, dt);
+      dispatch('dragend', srcEl, dt);
+    `,
       fromEl,
       toEl
     );
@@ -257,25 +281,22 @@ export class DomInteractions {
     const el = await this.resolveUid(uid);
 
     // Ensure it's an <input type=file>; if hidden, unhide via JS
-    await this.driver.executeScript((element: Element) => {
-      if (!element) {
-        throw new Error('uploadFile: element not found');
-      }
-      if (element.tagName !== 'INPUT' || (element as HTMLInputElement).type !== 'file') {
+    await this.driver.executeScript(
+      `
+      var element = arguments[0];
+      if (!element) throw new Error('uploadFile: element not found');
+      if (element.tagName !== 'INPUT' || element.type !== 'file')
         throw new Error('uploadFile: element must be <input type=file>');
-      }
-      const style = window.getComputedStyle(element);
+      var style = window.getComputedStyle(element);
       if (style.display === 'none' || style.visibility === 'hidden' || style.opacity === '0') {
-        const s = (element as HTMLElement).style;
-        s.display = 'block';
-        s.visibility = 'visible';
-        s.opacity = '1';
-        s.position = 'fixed';
-        s.left = '0px';
-        s.top = '0px';
+        var s = element.style;
+        s.display = 'block'; s.visibility = 'visible'; s.opacity = '1';
+        s.position = 'fixed'; s.left = '0px'; s.top = '0px';
         s.zIndex = '2147483647';
       }
-    }, el);
+    `,
+      el
+    );
 
     await el.sendKeys(filePath);
 

--- a/src/firefox/index.ts
+++ b/src/firefox/index.ts
@@ -3,7 +3,7 @@
  */
 
 import type { FirefoxLaunchOptions, ConsoleMessage } from './types.js';
-import { FirefoxCore } from './core.js';
+import { FirefoxCore, type IElement } from './core.js';
 import { ConsoleEvents, NetworkEvents } from './events/index.js';
 import { DomInteractions } from './dom.js';
 import { PageManagement } from './pages.js';
@@ -45,17 +45,23 @@ export class FirefoxClient {
     };
 
     // Initialize event modules with lifecycle hooks
-    // Note: autoClearOnNavigate is false to preserve logs across all tabs
-    // Users can manually call clearConsoleMessages() if needed
-    this.consoleEvents = new ConsoleEvents(driver, {
-      onNavigate,
-      autoClearOnNavigate: false,
-    });
+    // BiDi-dependent modules (console/network events) require a full WebDriver with
+    // BiDi support. When using --connect-existing, we bypass selenium's BiDi layer
+    // so these modules are not available.
+    const hasBidi = 'getBidi' in driver && typeof driver.getBidi === 'function';
 
-    this.networkEvents = new NetworkEvents(driver, {
-      onNavigate,
-      autoClearOnNavigate: false,
-    });
+    if (hasBidi) {
+      // Cast to any for BiDi-specific APIs that only exist on selenium WebDriver
+      this.consoleEvents = new ConsoleEvents(driver as any, {
+        onNavigate,
+        autoClearOnNavigate: false,
+      });
+
+      this.networkEvents = new NetworkEvents(driver as any, {
+        onNavigate,
+        autoClearOnNavigate: false,
+      });
+    }
 
     // Initialize DOM with UID resolver callback
     this.dom = new DomInteractions(driver, (uid: string) =>
@@ -69,9 +75,12 @@ export class FirefoxClient {
     );
 
     // Subscribe to console and network events for ALL contexts (not just current)
-    // This ensures we capture logs from all tabs, not just the initial one
-    await this.consoleEvents.subscribe(undefined);
-    await this.networkEvents.subscribe(undefined);
+    if (this.consoleEvents) {
+      await this.consoleEvents.subscribe(undefined);
+    }
+    if (this.networkEvents) {
+      await this.networkEvents.subscribe(undefined);
+    }
   }
 
   // ============================================================================
@@ -177,14 +186,14 @@ export class FirefoxClient {
 
   async getConsoleMessages(): Promise<ConsoleMessage[]> {
     if (!this.consoleEvents) {
-      throw new Error('Not connected');
+      throw new Error('Console events not available in connect-existing mode (requires BiDi)');
     }
     return this.consoleEvents.getMessages();
   }
 
   clearConsoleMessages(): void {
     if (!this.consoleEvents) {
-      throw new Error('Not connected');
+      throw new Error('Console events not available in connect-existing mode (requires BiDi)');
     }
     this.consoleEvents.clearMessages();
   }
@@ -285,28 +294,28 @@ export class FirefoxClient {
 
   async startNetworkMonitoring(): Promise<void> {
     if (!this.networkEvents) {
-      throw new Error('Not connected');
+      throw new Error('Network events not available in connect-existing mode (requires BiDi)');
     }
     this.networkEvents.startMonitoring();
   }
 
   async stopNetworkMonitoring(): Promise<void> {
     if (!this.networkEvents) {
-      throw new Error('Not connected');
+      throw new Error('Network events not available in connect-existing mode (requires BiDi)');
     }
     this.networkEvents.stopMonitoring();
   }
 
   async getNetworkRequests(): Promise<any[]> {
     if (!this.networkEvents) {
-      throw new Error('Not connected');
+      throw new Error('Network events not available in connect-existing mode (requires BiDi)');
     }
     return this.networkEvents.getRequests();
   }
 
   clearNetworkRequests(): void {
     if (!this.networkEvents) {
-      throw new Error('Not connected');
+      throw new Error('Network events not available in connect-existing mode (requires BiDi)');
     }
     this.networkEvents.clearRequests();
   }
@@ -329,7 +338,7 @@ export class FirefoxClient {
     return this.snapshot.resolveUidToSelector(uid);
   }
 
-  async resolveUidToElement(uid: string): Promise<any> {
+  async resolveUidToElement(uid: string): Promise<IElement> {
     if (!this.snapshot) {
       throw new Error('Not connected');
     }

--- a/src/firefox/pages.ts
+++ b/src/firefox/pages.ts
@@ -2,12 +2,12 @@
  * Page/Tab/Window management
  */
 
-import type { WebDriver } from 'selenium-webdriver';
+import type { IDriver } from './core.js';
 import { log } from '../utils/logger.js';
 
 export class PageManagement {
   constructor(
-    private driver: WebDriver,
+    private driver: IDriver,
     private getCurrentContextId: () => string | null,
     private setCurrentContextId: (id: string) => void
   ) {}

--- a/src/firefox/snapshot/manager.ts
+++ b/src/firefox/snapshot/manager.ts
@@ -3,7 +3,7 @@
  * Handles snapshot creation using bundled injected script
  */
 
-import type { WebDriver, WebElement } from 'selenium-webdriver';
+import type { IDriver, IElement } from '../core.js';
 import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -25,12 +25,12 @@ export interface SnapshotOptions {
  * Uses bundled injected script for snapshot creation
  */
 export class SnapshotManager {
-  private driver: WebDriver;
+  private driver: IDriver;
   private resolver: UidResolver;
   private injectedScript: string | null = null;
   private currentSnapshotId = 0;
 
-  constructor(driver: WebDriver) {
+  constructor(driver: IDriver) {
     this.driver = driver;
     this.resolver = new UidResolver(driver);
   }
@@ -159,7 +159,7 @@ export class SnapshotManager {
   /**
    * Resolve UID to WebElement (with staleness check and caching)
    */
-  async resolveUidToElement(uid: string): Promise<WebElement> {
+  async resolveUidToElement(uid: string): Promise<IElement> {
     return await this.resolver.resolveUidToElement(uid);
   }
 

--- a/src/firefox/snapshot/resolver.ts
+++ b/src/firefox/snapshot/resolver.ts
@@ -3,10 +3,17 @@
  * Handles UID validation, resolution to selectors/elements, and element caching
  */
 
-import type { WebDriver, WebElement } from 'selenium-webdriver';
-import { By } from 'selenium-webdriver';
+import type { IDriver, IElement } from '../core.js';
 import { logDebug } from '../../utils/logger.js';
-import type { UidEntry, ElementCacheEntry } from './types.js';
+import type { UidEntry } from './types.js';
+
+interface IElementCacheEntry {
+  selector: string;
+  xpath?: string;
+  cachedElement: IElement;
+  snapshotId: number;
+  timestamp: number;
+}
 
 /**
  * UID Resolver class
@@ -14,10 +21,10 @@ import type { UidEntry, ElementCacheEntry } from './types.js';
  */
 export class UidResolver {
   private uidToEntry = new Map<string, UidEntry>();
-  private elementCache = new Map<string, ElementCacheEntry>();
+  private elementCache = new Map<string, IElementCacheEntry>();
   private currentSnapshotId = 0;
 
-  constructor(private driver: WebDriver) {}
+  constructor(private driver: IDriver) {}
 
   /**
    * Update current snapshot ID
@@ -88,10 +95,10 @@ export class UidResolver {
   }
 
   /**
-   * Resolve UID to WebElement (with staleness check and caching)
+   * Resolve UID to element (with staleness check and caching)
    * Tries CSS first, falls back to XPath
    */
-  async resolveUidToElement(uid: string): Promise<WebElement> {
+  async resolveUidToElement(uid: string): Promise<IElement> {
     this.validateUid(uid);
 
     const entry = this.uidToEntry.get(uid);
@@ -107,7 +114,7 @@ export class UidResolver {
         await cached.cachedElement.isDisplayed();
         logDebug(`Using cached element for UID: ${uid}`);
         return cached.cachedElement;
-      } catch (e) {
+      } catch {
         // Element is stale, re-find it
         logDebug(`Cached element stale for UID: ${uid}, re-finding...`);
       }
@@ -115,7 +122,7 @@ export class UidResolver {
 
     // Try CSS selector first
     try {
-      const element = await this.driver.findElement(By.css(entry.css));
+      const element = await this.driver.findElement({ using: 'css selector', value: entry.css });
 
       // Update cache
       this.elementCache.set(uid, {
@@ -128,14 +135,14 @@ export class UidResolver {
 
       logDebug(`Found element by CSS for UID: ${uid}`);
       return element;
-    } catch (cssError) {
+    } catch {
       logDebug(`CSS selector failed for UID: ${uid}, trying XPath fallback...`);
 
       // Fallback to XPath if available
       const xpathSelector = entry.xpath;
       if (xpathSelector) {
         try {
-          const element = await this.driver.findElement(By.xpath(xpathSelector));
+          const element = await this.driver.findElement({ using: 'xpath', value: xpathSelector });
 
           // Update cache
           this.elementCache.set(uid, {
@@ -148,7 +155,7 @@ export class UidResolver {
 
           logDebug(`Found element by XPath for UID: ${uid}`);
           return element;
-        } catch (xpathError) {
+        } catch {
           throw new Error(
             `Element not found for UID: ${uid}. The element may have changed. Take a fresh snapshot.`
           );

--- a/src/firefox/snapshot/types.ts
+++ b/src/firefox/snapshot/types.ts
@@ -2,7 +2,7 @@
  * Snapshot types and interfaces
  */
 
-import type { WebElement } from 'selenium-webdriver';
+import type { IElement } from '../core.js';
 
 /**
  * UID entry with CSS and XPath selectors
@@ -100,7 +100,7 @@ export interface InjectedScriptResult {
 export interface ElementCacheEntry {
   selector: string;
   xpath?: string;
-  cachedElement?: WebElement;
+  cachedElement?: IElement;
   snapshotId: number;
   timestamp: number;
 }

--- a/src/firefox/types.ts
+++ b/src/firefox/types.ts
@@ -58,6 +58,8 @@ export interface FirefoxLaunchOptions {
   args?: string[] | undefined;
   startUrl?: string | undefined;
   acceptInsecureCerts?: boolean | undefined;
+  connectExisting?: boolean | undefined;
+  marionettePort?: number | undefined;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,6 +92,8 @@ export async function getFirefox(): Promise<FirefoxDevTools> {
     args: (args.firefoxArg as string[] | undefined) ?? undefined,
     startUrl: args.startUrl ?? undefined,
     acceptInsecureCerts: args.acceptInsecureCerts,
+    connectExisting: args.connectExisting,
+    marionettePort: args.marionettePort,
   };
 
   firefox = new FirefoxDevTools(options);


### PR DESCRIPTION
## Summary

- Adds `--connect-existing` and `--marionette-port` CLI options to connect to an already-running Firefox instance via Marionette, instead of always launching a new browser
- Introduces `GeckodriverHttpDriver` — a thin HTTP client that manages geckodriver and talks to its WebDriver REST API directly via `fetch()`, bypassing selenium-webdriver entirely
- BiDi-dependent features (console events, network events) are gracefully skipped in connect-existing mode; all other features work (snapshots, clicks, navigation, screenshots, tab management)

## Motivation

When using firefox-devtools-mcp as an AI coding assistant's browser tool, users want to automate their **existing** browsing session — with cookies, logins, and open tabs intact. The current behavior always launches a new, blank Firefox instance.

## Why bypass selenium-webdriver?

selenium-webdriver's `Driver.createSession()` auto-detects BiDi capability in the session response and tries to connect a WebSocket. When geckodriver runs in `--connect-existing` mode, it doesn't set up a WebSocket port (`--websocket-port` is intentionally skipped), so the BiDi upgrade hangs indefinitely — all subsequent WebDriver commands block forever.

The `GeckodriverHttpDriver` class avoids this entirely by talking to geckodriver's standard HTTP REST API.

## Usage

```bash
# Start Firefox with Marionette enabled
firefox --marionette

# In Firefox profile's user.js:
# user_pref("marionette.enabled", true);
# user_pref("marionette.port", 2828);

# Run the MCP server
npx firefox-devtools-mcp --connect-existing --marionette-port 2828
```

Also supports environment variables: `CONNECT_EXISTING=true MARIONETTE_PORT=2828`

## Test plan

- [x] Tested with Firefox 135 on Linux (EndeavourOS)
- [x] Verified tab listing shows actual open tabs from the user's session
- [x] Verified DOM snapshots work on real pages (Todoist, Home Assistant, Google Maps)
- [x] Verified close/reset only kills geckodriver, not the user's Firefox
- [x] Verified standard launch mode (without --connect-existing) still works unchanged
- [x] Verified BiDi-dependent modules (ConsoleEvents, NetworkEvents) are gracefully skipped
- [ ] Not yet tested on macOS or Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)