### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,3 +205,8 @@ npm run inspector:dev
 ## Author
 
 Maintained by [Mozilla](https://www.mozilla.org).
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/freema-firefox-devtools-mcp).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/freema-firefox-devtools-mcp)