### PR TITLE
docs: add MCP Find directory badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![CI](https://github.com/mozilla/firefox-devtools-mcp/workflows/CI/badge.svg)](https://github.com/mozilla/firefox-devtools-mcp/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/mozilla/firefox-devtools-mcp/branch/main/graph/badge.svg)](https://codecov.io/gh/mozilla/firefox-devtools-mcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Listed on MCP Find](https://img.shields.io/badge/MCP_Find-Listed-blue)](https://mcp-find.org/tools/firefox-devtools-mcp)
+
 
 <a href="https://glama.ai/mcp/servers/@mozilla/firefox-devtools-mcp"><img src="https://glama.ai/mcp/servers/@mozilla/firefox-devtools-mcp/badge" height="223" alt="Glama"></a>
 


### PR DESCRIPTION
Hi 👋

firefox-devtools-mcp is featured on [MCP Find](https://mcp-find.org/tools/firefox-devtools-mcp), 
a curated directory for the MCP ecosystem. The listing includes an 
editorial review, evidence profile, trust signals, and related 
tool comparisons.

This PR adds a small badge linking to the listing page.

**What MCP Find provides for firefox-devtools-mcp:**
- Dedicated tool profile with editorial review
- Trust/risk signal assessment  
- Comparison pages with related tools
- Integration into topic hubs
- Related workflow and learning guide links

Feel free to merge, modify placement, or close if you'd prefer 
not to include it. No pressure at all!

Preview: [firefox-devtools-mcp on MCP Find](https://mcp-find.org/tools/firefox-devtools-mcp)