### PR TITLE
feature: --profile-path should use a subfolder and warn about reusing existing profiles

### DIFF
--- a/src/firefox/core.ts
+++ b/src/firefox/core.ts
@@ -72,6 +72,7 @@ export class FirefoxCore {
   private originalEnv: Record<string, string | undefined> = {};
   private logFilePath: string | undefined;
   private logFileFd: number | undefined;
+  private profileWarning: string | null = null;
 
   constructor(private options: FirefoxLaunchOptions) {}
 
@@ -159,7 +160,8 @@ export class FirefoxCore {
         // Resolve to a dedicated MCP subfolder to avoid exposing a real user profile.
         // resolveProfilePath creates the directory on first use and warns when the
         // provided path already looks like a real Firefox profile.
-        const resolvedProfilePath = resolveProfilePath(this.options.profilePath);
+        const { path: resolvedProfilePath, warning } = resolveProfilePath(this.options.profilePath);
+        this.profileWarning = warning;
         // Use Firefox's native --profile argument for reliable profile loading
         // (Selenium's setProfile() copies to temp dir which can be unreliable)
         firefoxOptions.addArguments('--profile', resolvedProfilePath);
@@ -282,6 +284,16 @@ export class FirefoxCore {
    */
   getLogFilePath(): string | undefined {
     return this.logFilePath;
+  }
+
+  /**
+   * Get and clear the profile warning generated during connect() (if any).
+   * Consumed once by the first tool response so the MCP client surfaces it to the user.
+   */
+  getAndClearProfileWarning(): string | null {
+    const warning = this.profileWarning;
+    this.profileWarning = null;
+    return warning;
   }
 
   /**

--- a/src/firefox/core.ts
+++ b/src/firefox/core.ts
@@ -9,6 +9,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type { FirefoxLaunchOptions } from './types.js';
 import { log, logDebug } from '../utils/logger.js';
+import { resolveProfilePath } from './profile.js';
 
 // ---------------------------------------------------------------------------
 // Geckodriver binary finder — used only for --connect-existing mode
@@ -155,10 +156,14 @@ export class FirefoxCore {
         firefoxOptions.addArguments(...this.options.args);
       }
       if (this.options.profilePath) {
+        // Resolve to a dedicated MCP subfolder to avoid exposing a real user profile.
+        // resolveProfilePath creates the directory on first use and warns when the
+        // provided path already looks like a real Firefox profile.
+        const resolvedProfilePath = resolveProfilePath(this.options.profilePath);
         // Use Firefox's native --profile argument for reliable profile loading
         // (Selenium's setProfile() copies to temp dir which can be unreliable)
-        firefoxOptions.addArguments('--profile', this.options.profilePath);
-        log(`📁 Using Firefox profile: ${this.options.profilePath}`);
+        firefoxOptions.addArguments('--profile', resolvedProfilePath);
+        log(`📁 Using Firefox profile: ${resolvedProfilePath}`);
       }
       if (this.options.acceptInsecureCerts) {
         firefoxOptions.setAcceptInsecureCerts(true);

--- a/src/firefox/index.ts
+++ b/src/firefox/index.ts
@@ -451,6 +451,14 @@ export class FirefoxClient {
   }
 
   /**
+   * Get and clear the profile warning generated during connect() (if any).
+   * Consumed once so the MCP client surfaces it to the user in the first tool response.
+   */
+  getAndClearProfileWarning(): string | null {
+    return this.core.getAndClearProfileWarning();
+  }
+
+  /**
    * Get current launch options
    */
   getOptions(): FirefoxLaunchOptions {

--- a/src/firefox/profile.ts
+++ b/src/firefox/profile.ts
@@ -1,0 +1,70 @@
+/**
+ * Profile path resolution for Firefox DevTools MCP
+ *
+ * Rather than using a user-provided path directly as the Firefox profile,
+ * we create a dedicated subfolder. This prevents accidentally reusing a real
+ * browser profile (with bookmarks, saved passwords, cookies, …) inside an
+ * automated/remote-accessible session.
+ */
+
+import { existsSync, mkdirSync, copyFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { log } from '../utils/logger.js';
+
+export const MCP_PROFILE_DIR_NAME = 'firefox_devtools_mcp_profile';
+
+/**
+ * Files that are characteristic of an existing Firefox profile directory.
+ * Their presence indicates the user may have pointed at their real profile.
+ */
+const FIREFOX_PROFILE_INDICATORS = ['prefs.js', 'places.sqlite', 'cert9.db', 'key4.db'];
+
+/**
+ * Returns true when the given directory looks like an existing Firefox profile.
+ */
+export function isFirefoxProfile(dir: string): boolean {
+  return FIREFOX_PROFILE_INDICATORS.some((file) => existsSync(join(dir, file)));
+}
+
+/**
+ * Resolves a user-supplied profile path to a safe, MCP-specific subfolder.
+ *
+ * Given `parentPath`, the function:
+ * 1. Appends `firefox_devtools_mcp_profile` to form the real profile path.
+ * 2. Warns when `parentPath` itself looks like a real Firefox profile.
+ * 3. Creates the subfolder on first use.
+ * 4. On first creation, copies `prefs.js` from the parent into the new profile
+ *    so that user preferences carry over (browser_toolbox-style bootstrap).
+ *
+ * @returns The resolved, MCP-specific profile directory path.
+ */
+export function resolveProfilePath(parentPath: string): string {
+  const mcpProfilePath = join(parentPath, MCP_PROFILE_DIR_NAME);
+
+  if (isFirefoxProfile(parentPath)) {
+    log(
+      `⚠️  The path "${parentPath}" looks like an existing Firefox profile.\n` +
+        `   It will NOT be used directly. Instead, a dedicated MCP profile will be\n` +
+        `   created at: ${mcpProfilePath}\n` +
+        `   This keeps your real profile safe from automated browser access.\n` +
+        `   If you want to connect to your real profile, start Firefox yourself with\n` +
+        `   --remote-debugging-port and use --connect-existing instead.`
+    );
+  }
+
+  const isNew = !existsSync(mcpProfilePath);
+
+  if (isNew) {
+    mkdirSync(mcpProfilePath, { recursive: true });
+    log(`📁 Created MCP profile directory: ${mcpProfilePath}`);
+
+    // Bootstrap: copy prefs.js from the parent so user preferences are preserved.
+    const parentPrefs = join(parentPath, 'prefs.js');
+    if (existsSync(parentPrefs)) {
+      copyFileSync(parentPrefs, join(mcpProfilePath, 'prefs.js'));
+      log(`   Copied prefs.js from parent profile for initial preferences.`);
+    }
+  }
+
+  return mcpProfilePath;
+}

--- a/src/firefox/profile.ts
+++ b/src/firefox/profile.ts
@@ -26,6 +26,12 @@ export function isFirefoxProfile(dir: string): boolean {
   return FIREFOX_PROFILE_INDICATORS.some((file) => existsSync(join(dir, file)));
 }
 
+export interface ResolvedProfile {
+  path: string;
+  /** Warning to surface to the user (e.g. when a real Firefox profile was detected). */
+  warning: string | null;
+}
+
 /**
  * Resolves a user-supplied profile path to a safe, MCP-specific subfolder.
  *
@@ -36,20 +42,21 @@ export function isFirefoxProfile(dir: string): boolean {
  * 4. On first creation, copies `prefs.js` from the parent into the new profile
  *    so that user preferences carry over (browser_toolbox-style bootstrap).
  *
- * @returns The resolved, MCP-specific profile directory path.
+ * @returns The resolved path and an optional warning string.
  */
-export function resolveProfilePath(parentPath: string): string {
+export function resolveProfilePath(parentPath: string): ResolvedProfile {
   const mcpProfilePath = join(parentPath, MCP_PROFILE_DIR_NAME);
 
+  let warning: string | null = null;
   if (isFirefoxProfile(parentPath)) {
-    log(
+    warning =
       `⚠️  The path "${parentPath}" looks like an existing Firefox profile.\n` +
-        `   It will NOT be used directly. Instead, a dedicated MCP profile will be\n` +
-        `   created at: ${mcpProfilePath}\n` +
-        `   This keeps your real profile safe from automated browser access.\n` +
-        `   If you want to connect to your real profile, start Firefox yourself with\n` +
-        `   --remote-debugging-port and use --connect-existing instead.`
-    );
+      `   It will NOT be used directly. Instead, a dedicated MCP profile will be\n` +
+      `   created at: ${mcpProfilePath}\n` +
+      `   This keeps your real profile safe from automated browser access.\n` +
+      `   If you want to connect to your real profile, start Firefox yourself with\n` +
+      `   --remote-debugging-port and use --connect-existing instead.`;
+    log(warning);
   }
 
   const isNew = !existsSync(mcpProfilePath);
@@ -66,5 +73,5 @@ export function resolveProfilePath(parentPath: string): string {
     }
   }
 
-  return mcpProfilePath;
+  return { path: mcpProfilePath, warning };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ import { FirefoxDevTools } from './firefox/index.js';
 import type { FirefoxLaunchOptions } from './firefox/types.js';
 import * as tools from './tools/index.js';
 import type { McpToolResponse } from './types/common.js';
+import { errorResponse } from './utils/response-helpers.js';
 
 // Export for direct usage in scripts
 export { FirefoxDevTools } from './firefox/index.js';
@@ -57,6 +58,8 @@ export const args = parseArguments(SERVER_VERSION);
 // Global context (lazy initialized on first tool call)
 let firefox: FirefoxDevTools | null = null;
 let nextLaunchOptions: FirefoxLaunchOptions | null = null;
+// Warning generated during Firefox startup, surfaced in the first tool response.
+let pendingWarning: string | null = null;
 
 /**
  * Reset Firefox instance (used when disconnection is detected)
@@ -66,6 +69,7 @@ export function resetFirefox(): void {
     firefox.reset();
     firefox = null;
   }
+  pendingWarning = null;
   log('Firefox instance reset - will reconnect on next tool call');
 }
 
@@ -151,6 +155,7 @@ export async function getFirefox(): Promise<FirefoxDevTools> {
   try {
     await firefox.connect();
     log('Firefox DevTools connection established');
+    pendingWarning = firefox.getAndClearProfileWarning();
     return firefox;
   } catch (error) {
     // Clean up before discarding — ensures the geckodriver process is killed
@@ -341,7 +346,20 @@ async function main() {
     }
 
     try {
-      return await handler(args);
+      const result = await handler(args);
+      if (pendingWarning) {
+        // Return as isError so that agents acting as MCP clients (e.g. Claude)
+        // surface the message to the user.
+        // Also note the operation completed so the agent does not retry.
+        const operationNote =
+          result.content[0]?.type === 'text'
+            ? `\n\n[Note: The operation also completed — ${result.content[0].text}]`
+            : '';
+        const warning = pendingWarning;
+        pendingWarning = null;
+        return errorResponse(`${warning}${operationNote}`);
+      }
+      return result;
     } catch (error) {
       logError(`Error executing tool ${name}`, error);
       throw error;

--- a/tests/firefox/core.test.ts
+++ b/tests/firefox/core.test.ts
@@ -118,9 +118,18 @@ describe('FirefoxCore connect() profile handling', () => {
       })),
       Browser: { FIREFOX: 'firefox' },
     }));
+
+    // Mock node:fs so profile.ts doesn't touch the real filesystem
+    vi.doMock('node:fs', () => ({
+      existsSync: vi.fn().mockReturnValue(false),
+      mkdirSync: vi.fn(),
+      copyFileSync: vi.fn(),
+      openSync: vi.fn().mockReturnValue(3),
+      closeSync: vi.fn(),
+    }));
   });
 
-  it('should pass profile path via --profile argument instead of setProfile', async () => {
+  it('should pass the MCP-specific profile subfolder via --profile argument instead of setProfile', async () => {
     const { FirefoxCore } = await import('@/firefox/core.js');
 
     const profilePath = '/path/to/test/profile';
@@ -134,7 +143,11 @@ describe('FirefoxCore connect() profile handling', () => {
     // Assert: setProfile should NOT be called (it copies to temp dir)
     expect(mockSetProfile).not.toHaveBeenCalled();
 
-    expect(mockAddArguments).toHaveBeenCalledWith('--profile', profilePath);
+    // The MCP uses a dedicated subfolder, not the raw profilePath
+    expect(mockAddArguments).toHaveBeenCalledWith(
+      '--profile',
+      '/path/to/test/profile/firefox_devtools_mcp_profile'
+    );
   });
 });
 

--- a/tests/firefox/profile.test.ts
+++ b/tests/firefox/profile.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Unit tests for profile path resolution
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  copyFileSync: vi.fn(),
+}));
+
+vi.mock('@/utils/logger.js', () => ({
+  log: vi.fn(),
+  logDebug: vi.fn(),
+}));
+
+import * as fs from 'node:fs';
+import { resolveProfilePath, isFirefoxProfile, MCP_PROFILE_DIR_NAME } from '@/firefox/profile.js';
+
+const mockExistsSync = vi.mocked(fs.existsSync);
+const mockMkdirSync = vi.mocked(fs.mkdirSync);
+const mockCopyFileSync = vi.mocked(fs.copyFileSync);
+
+const SEP = '/';
+
+describe('isFirefoxProfile', () => {
+  beforeEach(() => {
+    mockExistsSync.mockReset();
+  });
+
+  it('returns false when directory has no Firefox profile indicators', () => {
+    mockExistsSync.mockReturnValue(false);
+    expect(isFirefoxProfile('/some/random/dir')).toBe(false);
+  });
+
+  it('returns true when prefs.js is present', () => {
+    mockExistsSync.mockImplementation((p: unknown) => String(p).endsWith('prefs.js'));
+    expect(isFirefoxProfile('/real/profile')).toBe(true);
+  });
+
+  it('returns true when places.sqlite is present', () => {
+    mockExistsSync.mockImplementation((p: unknown) => String(p).endsWith('places.sqlite'));
+    expect(isFirefoxProfile('/real/profile')).toBe(true);
+  });
+});
+
+describe('resolveProfilePath', () => {
+  beforeEach(() => {
+    mockExistsSync.mockReset();
+    mockMkdirSync.mockReset();
+    mockCopyFileSync.mockReset();
+  });
+
+  it('returns the MCP subfolder path', () => {
+    mockExistsSync.mockReturnValue(false);
+    const result = resolveProfilePath('/custom/profiles');
+    expect(result).toBe(`/custom/profiles${SEP}${MCP_PROFILE_DIR_NAME}`);
+  });
+
+  it('creates the MCP subfolder when it does not exist yet', () => {
+    mockExistsSync.mockReturnValue(false);
+    resolveProfilePath('/custom/profiles');
+    expect(mockMkdirSync).toHaveBeenCalledWith(`/custom/profiles${SEP}${MCP_PROFILE_DIR_NAME}`, {
+      recursive: true,
+    });
+  });
+
+  it('does not create the directory when it already exists', () => {
+    // Simulate: no profile indicators in parent, but MCP subfolder already exists.
+    mockExistsSync.mockImplementation(
+      (p: unknown) => String(p) === `/custom/profiles${SEP}${MCP_PROFILE_DIR_NAME}`
+    );
+    resolveProfilePath('/custom/profiles');
+    expect(mockMkdirSync).not.toHaveBeenCalled();
+  });
+
+  it('copies prefs.js from parent on first creation when present', () => {
+    // Parent has prefs.js (indicator + copy source), MCP subfolder does not exist yet.
+    mockExistsSync.mockImplementation((p: unknown) => {
+      const path = String(p);
+      // Return true for prefs.js indicator AND for the parent prefs.js source,
+      // but false for the MCP subfolder itself (isNew = true).
+      return path.endsWith('prefs.js') && !path.includes(MCP_PROFILE_DIR_NAME);
+    });
+    resolveProfilePath('/real/profile');
+    expect(mockCopyFileSync).toHaveBeenCalledWith(
+      `/real/profile${SEP}prefs.js`,
+      `/real/profile${SEP}${MCP_PROFILE_DIR_NAME}${SEP}prefs.js`
+    );
+  });
+
+  it('does not copy prefs.js when parent has no prefs.js', () => {
+    mockExistsSync.mockReturnValue(false);
+    resolveProfilePath('/custom/profiles');
+    expect(mockCopyFileSync).not.toHaveBeenCalled();
+  });
+
+  it('does not copy prefs.js when MCP subfolder already existed', () => {
+    // Both MCP subfolder and parent prefs.js exist — not a new profile.
+    mockExistsSync.mockReturnValue(true);
+    resolveProfilePath('/real/profile');
+    expect(mockCopyFileSync).not.toHaveBeenCalled();
+  });
+});

--- a/tests/firefox/profile.test.ts
+++ b/tests/firefox/profile.test.ts
@@ -55,7 +55,19 @@ describe('resolveProfilePath', () => {
   it('returns the MCP subfolder path', () => {
     mockExistsSync.mockReturnValue(false);
     const result = resolveProfilePath('/custom/profiles');
-    expect(result).toBe(`/custom/profiles${SEP}${MCP_PROFILE_DIR_NAME}`);
+    expect(result.path).toBe(`/custom/profiles${SEP}${MCP_PROFILE_DIR_NAME}`);
+  });
+
+  it('returns null warning for a non-Firefox directory', () => {
+    mockExistsSync.mockReturnValue(false);
+    const result = resolveProfilePath('/custom/profiles');
+    expect(result.warning).toBeNull();
+  });
+
+  it('returns a warning when the parent looks like a real Firefox profile', () => {
+    mockExistsSync.mockImplementation((p: unknown) => String(p).endsWith('prefs.js'));
+    const result = resolveProfilePath('/real/profile');
+    expect(result.warning).toMatch(/looks like an existing Firefox profile/);
   });
 
   it('creates the MCP subfolder when it does not exist yet', () => {


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=2032351

This PR makes --profile-path safer by routing Firefox through a dedicated firefox_devtools_mcp_profile/ subfolder instead of using the provided path directly. This prevents MCP from accessing a real Firefox profile (with passwords, cookies, bookmarks) in an automated session.

On first use, the subfolder is created and prefs.js is copied from the parent so user preferences carry over. 

If the provided path looks like a real Firefox profile, a warning is surfaced to the user via the MCP tool response.