### PR TITLE
fix(claude): correct network status type mismatch in debug command

### DIFF
--- a/plugins/claude/firefox-devtools/commands/debug.md
+++ b/plugins/claude/firefox-devtools/commands/debug.md
@@ -26,7 +26,7 @@ Displays debugging information from the current page.
 ## What Happens
 
 - `console`: Calls `list_console_messages` with `level="error"`
-- `network`: Calls `list_network_requests` with `status="failed"`
+- `network`: Calls `list_network_requests` with `statusMin=400`
 - `all` (default): Shows both console errors and failed network requests
 
 Useful for debugging page issues, JavaScript errors, and API failures.


### PR DESCRIPTION
The 'debug' command in the Claude Code plugin instructed the model to use `status="failed"` for network requests, which conflicted with the underlying tool's numerical schema in `src/tools/network.ts`.

This PR updates the command definition to use `statusMin=400`, which correctly captures all 4xx and 5xx errors and aligns with the existing implementation.

Verified using a reproduction script against the tool handler.