### PR TITLE
fix: use node to launch MCP server for Windows compatibility

### DIFF
--- a/plugins/claude/firefox-devtools/.mcp.json
+++ b/plugins/claude/firefox-devtools/.mcp.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "firefox-devtools": {
-      "command": "npx",
-      "args": ["-y", "firefox-devtools-mcp@latest"]
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/../../../dist/index.js"]
     }
   }
 }


### PR DESCRIPTION
On Windows, `npx` is a .cmd batch file that cannot be spawned directly by Claude Code's MCP server launcher (which uses child_process.spawn without a shell). Claude Code detects this and shows the warning:

  Windows requires 'cmd /c' wrapper to execute npx

Without a fix, the MCP server silently fails to connect -- tools appear registered but every call fails indefinitely.

Replace `npx -y firefox-devtools-mcp@latest` with `node` pointing directly at the installed `dist/index.js` via `${CLAUDE_PLUGIN_ROOT}`. If I'm understanding things correctly, I think `node` (node.exe) is a real executable on all platforms and should always be spawn-able directly without a shell wrapper. It'd be great if someone can verify this on a non-win machine though. 

I verified on Windows 11 with Claude Code CLI in moz-build shell, and separately in git bash.