### PR TITLE
fix: create user home directory in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ COPY --from=builder /app/dist ./dist
 
 # Create non-root user
 RUN groupadd -g 1001 -r nodejs && \
-    useradd -r -g nodejs -u 1001 nodejs
+    useradd -r -g nodejs -u 1001 -m -d /home/nodejs nodejs
 
 # Change ownership of the app directory
 RUN chown -R nodejs:nodejs /app


### PR DESCRIPTION
This PR creates a home directory for the `nodejs` user inside the container. Firefox tries to create folders inside the home dir and without it (`nodejs` is a system user so it doesn't get a home directory created by default) crashes at runtime.