### PR TITLE
fix: kill zombie geckodriver when Firefox is closed

### DIFF
--- a/scripts/test-closed-window.js
+++ b/scripts/test-closed-window.js
@@ -1,0 +1,363 @@
+#!/usr/bin/env node
+/**
+ * Test: zombie geckodriver cleanup
+ *
+ * Two scenarios:
+ *
+ * Scenario A (SIGSTOP): Firefox is frozen and can't respond, so close() hangs.
+ *   Proves that killService() + reset() kills the zombie when close() can't.
+ *
+ * Scenario B (SIGKILL): Firefox is completely dead (user clicked [X]).
+ *   Recovery test: can we clean up and reconnect after Firefox dies?
+ *   Note: SIGKILL closes TCP sockets, so geckodriver often dies with Firefox.
+ *   A true zombie (geckodriver alive but stuck) is tested by Scenario A.
+ */
+import { FirefoxDevTools } from '../dist/index.js';
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+const CLOSE_TIMEOUT_MS = 5000;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function pgrep(pattern) {
+  try {
+    return execFileSync('pgrep', ['-f', pattern], { encoding: 'utf-8' })
+      .trim()
+      .split('\n')
+      .map(Number)
+      .filter((n) => !isNaN(n));
+  } catch {
+    return [];
+  }
+}
+
+function isAlive(pid) {
+  // /proc/pid/stat format: pid (comm) state ...
+  // The comm field can contain spaces, so we find state after the last ')'.
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, 'utf-8');
+    const closeParen = stat.lastIndexOf(')');
+    const state = stat[closeParen + 2];
+    return state !== 'Z';
+  } catch {
+    return false;
+  }
+}
+
+function killHard(pid) {
+  try {
+    process.kill(pid, 'SIGKILL');
+  } catch {}
+}
+
+function freeze(pid) {
+  try {
+    process.kill(pid, 'SIGSTOP');
+  } catch {}
+}
+
+function getDescendants(parentPid) {
+  const result = [];
+  const queue = [parentPid];
+  while (queue.length > 0) {
+    const pid = queue.shift();
+    try {
+      const output = execFileSync('pgrep', ['-P', String(pid)], {
+        encoding: 'utf-8',
+      });
+      const children = output
+        .trim()
+        .split('\n')
+        .map(Number)
+        .filter((n) => !isNaN(n));
+      result.push(...children);
+      queue.push(...children);
+    } catch {
+      // No children
+    }
+  }
+  return result;
+}
+
+function waitForDeath(pid, timeoutMs) {
+  return new Promise((resolve) => {
+    const start = Date.now();
+    const check = () => {
+      if (!isAlive(pid)) {
+        resolve(true);
+      } else if (Date.now() - start > timeoutMs) {
+        resolve(false);
+      } else {
+        setTimeout(check, 100);
+      }
+    };
+    check();
+  });
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function verifyFrozen(pids) {
+  for (const pid of pids) {
+    if (!isAlive(pid)) continue;
+    try {
+      const stat = readFileSync(`/proc/${pid}/stat`, 'utf-8');
+      const closeParen = stat.lastIndexOf(')');
+      const state = stat[closeParen + 2];
+      if (state !== 'T') {
+        return { ok: false, pid, state };
+      }
+    } catch {
+      // Process died — that's fine
+    }
+  }
+  return { ok: true };
+}
+
+// Suppress unhandled rejections from fire-and-forget promises
+process.on('unhandledRejection', () => {});
+
+// ---------------------------------------------------------------------------
+// Launch helper — creates FirefoxDevTools, connects, returns instance + PIDs
+// ---------------------------------------------------------------------------
+
+async function launchFirefox(geckosBefore, excludePids = []) {
+  const devTools = new FirefoxDevTools({
+    headless: true,
+    viewport: { width: 1280, height: 720 },
+  });
+  await devTools.connect();
+
+  const geckoPid = pgrep('geckodriver').find(
+    (p) => !geckosBefore.has(p) && !excludePids.includes(p)
+  );
+  if (!geckoPid) {
+    throw new Error('No geckodriver PID found after connect');
+  }
+
+  const firefoxPids = getDescendants(geckoPid);
+  if (firefoxPids.length === 0) {
+    killHard(geckoPid);
+    throw new Error('No Firefox PIDs found under geckodriver');
+  }
+
+  return { devTools, geckoPid, firefoxPids };
+}
+
+// ---------------------------------------------------------------------------
+// Test
+// ---------------------------------------------------------------------------
+
+async function main() {
+  console.log('--- Zombie geckodriver fix test ---\n');
+
+  const geckosBefore = new Set(pgrep('geckodriver'));
+
+  // ---------------------------------------------------------------
+  // Scenario A: Firefox frozen (SIGSTOP)
+  // ---------------------------------------------------------------
+  console.log('Scenario A: Firefox frozen (SIGSTOP)');
+
+  // Step 1: Launch Firefox
+  console.log('  1. Launching Firefox...');
+  const a = await launchFirefox(geckosBefore);
+  console.log(`     Geckodriver PID: ${a.geckoPid}`);
+  console.log(`     Firefox PIDs: ${a.firefoxPids.join(', ')}`);
+
+  // Step 2: Freeze Firefox
+  console.log('  2. Freezing Firefox (SIGSTOP)...');
+  for (const pid of a.firefoxPids) {
+    freeze(pid);
+  }
+  await sleep(500);
+  const frozen = verifyFrozen(a.firefoxPids);
+  if (!frozen.ok) {
+    console.error(`  [FATAL] Firefox PID ${frozen.pid} not frozen (state=${frozen.state})`);
+    for (const pid of a.firefoxPids) killHard(pid);
+    killHard(a.geckoPid);
+    process.exit(1);
+  }
+  console.log('     Firefox is frozen');
+
+  // Step 3: Try close() with a timeout — same pattern as production resetFirefox
+  console.log(`  3. Calling close() with ${CLOSE_TIMEOUT_MS}ms timeout...`);
+  let closeSucceeded = false;
+  let timer;
+  const closePromise = a.devTools.close().then(
+    () => { closeSucceeded = true; },
+    () => {}
+  );
+  const t0 = Date.now();
+  try {
+    await Promise.race([
+      closePromise,
+      new Promise((_, reject) => {
+        timer = setTimeout(() => reject(new Error('close timeout')), CLOSE_TIMEOUT_MS);
+      }),
+    ]);
+  } catch {
+    // close() didn't finish in time — expected when Firefox is frozen
+  } finally {
+    clearTimeout(timer);
+  }
+  const elapsed = Date.now() - t0;
+
+  if (closeSucceeded) {
+    console.log(`     close() completed in ${elapsed}ms`);
+  } else {
+    console.log(`     close() timed out after ~${elapsed}ms as expected`);
+    // Verify close() actually hung (not a quick rejection)
+    if (elapsed < 3000) {
+      console.error('  [FAIL] close() returned too fast — Scenario A did not hang as expected');
+      for (const pid of a.firefoxPids) killHard(pid);
+      killHard(a.geckoPid);
+      process.exit(1);
+    }
+  }
+
+  // Step 4: Kill the zombie — the actual fix under test
+  console.log('  4. Killing zombie geckodriver (killService + reset)...');
+  if (typeof a.devTools.killService === 'function') {
+    a.devTools.killService();
+    a.devTools.reset();
+  } else {
+    // Without killService, the zombie can't be killed from JS.
+    // SIGKILL it manually so we can continue testing.
+    console.log('     killService not available — zombie alive (this is the bug)');
+    killHard(a.geckoPid);
+    const died = await waitForDeath(a.geckoPid, 3000);
+    if (!died) {
+      console.error('  [FAIL] Could not kill zombie geckodriver even with SIGKILL');
+      process.exit(1);
+    }
+    console.log('  [FAIL] close() hung and killService is not available to kill zombie');
+    // Continue to clean up frozen Firefox, then exit
+    for (const pid of a.firefoxPids) killHard(pid);
+    process.exit(1);
+  }
+
+  // Step 5: Clean up frozen Firefox
+  console.log('  5. Cleaning up frozen Firefox...');
+  for (const pid of a.firefoxPids) {
+    killHard(pid);
+  }
+  await sleep(1000);
+
+  // Step 6: Verify geckodriver is dead
+  const geckoDiedA = await waitForDeath(a.geckoPid, 5000);
+  if (geckoDiedA) {
+    console.log('  6. Geckodriver is dead');
+  } else {
+    console.log('  [FAIL] Geckodriver still alive after killService + reset');
+    killHard(a.geckoPid);
+    process.exit(1);
+  }
+
+  // Step 7: Reconnect — verify a fresh session works
+  console.log('  7. Reconnecting...');
+  const a2 = await launchFirefox(geckosBefore, [a.geckoPid]);
+  await a2.devTools.navigate('about:blank');
+  console.log('     Navigation works');
+  await a2.devTools.close();
+  console.log('  Scenario A: PASS\n');
+
+  // ---------------------------------------------------------------
+  // Scenario B: Firefox killed (SIGKILL) — recovery test
+  // ---------------------------------------------------------------
+  console.log('Scenario B: Firefox killed (SIGKILL)');
+
+  // Step 1: Launch Firefox
+  console.log('  1. Launching Firefox...');
+  const b = await launchFirefox(geckosBefore, [a.geckoPid, a2.geckoPid]);
+  console.log(`     Geckodriver PID: ${b.geckoPid}`);
+  console.log(`     Firefox PIDs: ${b.firefoxPids.join(', ')}`);
+
+  // Step 2: Kill Firefox (simulates user clicking [X])
+  console.log('  2. Killing Firefox...');
+  for (const pid of b.firefoxPids) {
+    killHard(pid);
+  }
+  for (const pid of b.firefoxPids) {
+    const died = await waitForDeath(pid, 5000);
+    if (!died) {
+      console.error(`  [FATAL] Firefox PID ${pid} did not die after SIGKILL`);
+      killHard(b.geckoPid);
+      process.exit(1);
+    }
+  }
+  console.log('     Firefox is dead');
+
+  // Step 3: Check for zombie geckodriver
+  if (isAlive(b.geckoPid)) {
+    console.log('  3. Zombie geckodriver detected');
+  } else {
+    console.log('  3. Geckodriver died with Firefox (no zombie)');
+  }
+
+  // Step 4: Run cleanup — close with timeout, then killService + reset fallback
+  console.log('  4. Running cleanup (close with timeout, killService fallback)...');
+  let closeOk = false;
+  let timerB;
+  const closeB = b.devTools.close().then(
+    () => { closeOk = true; },
+    () => {}
+  );
+  try {
+    await Promise.race([
+      closeB,
+      new Promise((_, reject) => {
+        timerB = setTimeout(() => reject(new Error('close timeout')), CLOSE_TIMEOUT_MS);
+      }),
+    ]);
+  } catch {
+    // close() didn't finish in time
+  } finally {
+    clearTimeout(timerB);
+  }
+  if (!closeOk) {
+    if (typeof b.devTools.killService === 'function') {
+      b.devTools.killService();
+      b.devTools.reset();
+    } else {
+      console.log('     killService not available — killing zombie directly');
+      killHard(b.geckoPid);
+      await waitForDeath(b.geckoPid, 3000);
+      console.log('  [FAIL] killService is not available to kill zombie');
+      process.exit(1);
+    }
+  }
+
+  // Step 5: Verify geckodriver is dead
+  const geckoDiedB = await waitForDeath(b.geckoPid, 5000);
+  if (geckoDiedB) {
+    console.log('  5. Geckodriver is dead');
+  } else {
+    console.log('  [FAIL] Geckodriver still alive after cleanup');
+    killHard(b.geckoPid);
+    process.exit(1);
+  }
+
+  // Step 6: Reconnect — verify a fresh session works
+  console.log('  6. Reconnecting...');
+  const b2 = await launchFirefox(geckosBefore, [a.geckoPid, a2.geckoPid, b.geckoPid]);
+  await b2.devTools.navigate('about:blank');
+  console.log('     Navigation works');
+  await b2.devTools.close();
+  console.log('  Scenario B: PASS\n');
+
+  // Final cleanup
+  const leftover = pgrep('geckodriver').filter((p) => !geckosBefore.has(p));
+  for (const pid of leftover) {
+    killHard(pid);
+  }
+}
+
+main().catch((err) => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/scripts/test-closed-window.js
+++ b/scripts/test-closed-window.js
@@ -2,13 +2,11 @@
 /**
  * Test: zombie geckodriver cleanup
  *
- * Two scenarios:
- *
  * Scenario A (SIGSTOP): Firefox is frozen and can't respond, so close() hangs.
- *   Proves that killService() + reset() kills the zombie when close() can't.
+ *   Proves that close() force-kills the zombie via onQuit_() on timeout.
  *
  * Scenario B (SIGKILL): Firefox is completely dead (user clicked [X]).
- *   Recovery test: can we clean up and reconnect after Firefox dies?
+ *   Recovery test: can close() clean up and reconnect after Firefox dies?
  *   Note: SIGKILL closes TCP sockets, so geckodriver often dies with Firefox.
  *   A true zombie (geckodriver alive but stuck) is tested by Scenario A.
  */
@@ -16,35 +14,38 @@ import { FirefoxDevTools } from '../dist/index.js';
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 
-const CLOSE_TIMEOUT_MS = 5000;
-
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
+function parsePids(output) {
+  return output
+    .trim()
+    .split('\n')
+    .map(Number)
+    .filter((n) => !isNaN(n));
+}
+
 function pgrep(pattern) {
   try {
-    return execFileSync('pgrep', ['-f', pattern], { encoding: 'utf-8' })
-      .trim()
-      .split('\n')
-      .map(Number)
-      .filter((n) => !isNaN(n));
+    return parsePids(execFileSync('pgrep', ['-f', pattern], { encoding: 'utf-8' }));
   } catch {
     return [];
   }
 }
 
-function isAlive(pid) {
-  // /proc/pid/stat format: pid (comm) state ...
-  // The comm field can contain spaces, so we find state after the last ')'.
+function getProcState(pid) {
   try {
     const stat = readFileSync(`/proc/${pid}/stat`, 'utf-8');
-    const closeParen = stat.lastIndexOf(')');
-    const state = stat[closeParen + 2];
-    return state !== 'Z';
+    return stat[stat.lastIndexOf(')') + 2];
   } catch {
-    return false;
+    return null;
   }
+}
+
+function isAlive(pid) {
+  const state = getProcState(pid);
+  return state !== null && state !== 'Z';
 }
 
 function killHard(pid) {
@@ -65,19 +66,10 @@ function getDescendants(parentPid) {
   while (queue.length > 0) {
     const pid = queue.shift();
     try {
-      const output = execFileSync('pgrep', ['-P', String(pid)], {
-        encoding: 'utf-8',
-      });
-      const children = output
-        .trim()
-        .split('\n')
-        .map(Number)
-        .filter((n) => !isNaN(n));
+      const children = parsePids(execFileSync('pgrep', ['-P', String(pid)], { encoding: 'utf-8' }));
       result.push(...children);
       queue.push(...children);
-    } catch {
-      // No children
-    }
+    } catch {}
   }
   return result;
 }
@@ -86,49 +78,38 @@ function waitForDeath(pid, timeoutMs) {
   return new Promise((resolve) => {
     const start = Date.now();
     const check = () => {
-      if (!isAlive(pid)) {
-        resolve(true);
-      } else if (Date.now() - start > timeoutMs) {
-        resolve(false);
-      } else {
-        setTimeout(check, 100);
-      }
+      if (!isAlive(pid)) resolve(true);
+      else if (Date.now() - start > timeoutMs) resolve(false);
+      else setTimeout(check, 100);
     };
     check();
   });
 }
 
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function killAll(pids) {
+  for (const pid of pids) killHard(pid);
 }
 
-function verifyFrozen(pids) {
-  for (const pid of pids) {
-    if (!isAlive(pid)) continue;
-    try {
-      const stat = readFileSync(`/proc/${pid}/stat`, 'utf-8');
-      const closeParen = stat.lastIndexOf(')');
-      const state = stat[closeParen + 2];
-      if (state !== 'T') {
-        return { ok: false, pid, state };
-      }
-    } catch {
-      // Process died — that's fine
-    }
-  }
-  return { ok: true };
+async function reconnect(geckosBefore, excludePids) {
+  const r = await launchFirefox(geckosBefore, excludePids);
+  await r.devTools.navigate('about:blank');
+  console.log('     Navigation works');
+  await r.devTools.close();
+  return r.geckoPid;
 }
 
-// Suppress unhandled rejections from fire-and-forget promises
-process.on('unhandledRejection', () => {});
+// Log unhandled rejections instead of swallowing them silently
+process.on('unhandledRejection', (reason) => {
+  console.error('[unhandled rejection]', reason);
+});
 
 // ---------------------------------------------------------------------------
-// Launch helper — creates FirefoxDevTools, connects, returns instance + PIDs
+// Launch helper
 // ---------------------------------------------------------------------------
 
-async function launchFirefox(geckosBefore, excludePids = []) {
+async function launchFirefox(geckosBefore, excludePids = [], headless = true) {
   const devTools = new FirefoxDevTools({
-    headless: true,
+    headless,
     viewport: { width: 1280, height: 720 },
   });
   await devTools.connect();
@@ -136,9 +117,7 @@ async function launchFirefox(geckosBefore, excludePids = []) {
   const geckoPid = pgrep('geckodriver').find(
     (p) => !geckosBefore.has(p) && !excludePids.includes(p)
   );
-  if (!geckoPid) {
-    throw new Error('No geckodriver PID found after connect');
-  }
+  if (!geckoPid) throw new Error('No geckodriver PID found after connect');
 
   const firefoxPids = getDescendants(geckoPid);
   if (firefoxPids.length === 0) {
@@ -155,204 +134,132 @@ async function launchFirefox(geckosBefore, excludePids = []) {
 
 async function main() {
   console.log('--- Zombie geckodriver fix test ---\n');
-
   const geckosBefore = new Set(pgrep('geckodriver'));
+  const usedPids = [];
 
   // ---------------------------------------------------------------
   // Scenario A: Firefox frozen (SIGSTOP)
   // ---------------------------------------------------------------
   console.log('Scenario A: Firefox frozen (SIGSTOP)');
 
-  // Step 1: Launch Firefox
   console.log('  1. Launching Firefox...');
   const a = await launchFirefox(geckosBefore);
-  console.log(`     Geckodriver PID: ${a.geckoPid}`);
-  console.log(`     Firefox PIDs: ${a.firefoxPids.join(', ')}`);
+  console.log(`     Geckodriver PID: ${a.geckoPid}, Firefox PIDs: ${a.firefoxPids.join(', ')}`);
 
-  // Step 2: Freeze Firefox
   console.log('  2. Freezing Firefox (SIGSTOP)...');
-  for (const pid of a.firefoxPids) {
-    freeze(pid);
-  }
-  await sleep(500);
-  const frozen = verifyFrozen(a.firefoxPids);
-  if (!frozen.ok) {
-    console.error(`  [FATAL] Firefox PID ${frozen.pid} not frozen (state=${frozen.state})`);
-    for (const pid of a.firefoxPids) killHard(pid);
-    killHard(a.geckoPid);
+  for (const pid of a.firefoxPids) freeze(pid);
+  const allFrozen = a.firefoxPids.every((pid) => !isAlive(pid) || getProcState(pid) === 'T');
+  if (!allFrozen) {
+    console.error('  [FATAL] Firefox not frozen');
+    killAll([...a.firefoxPids, a.geckoPid]);
     process.exit(1);
   }
   console.log('     Firefox is frozen');
 
-  // Step 3: Try close() with a timeout — same pattern as production resetFirefox
-  console.log(`  3. Calling close() with ${CLOSE_TIMEOUT_MS}ms timeout...`);
-  let closeSucceeded = false;
-  let timer;
-  const closePromise = a.devTools.close().then(
-    () => { closeSucceeded = true; },
-    () => {}
-  );
+  console.log('  3. Calling close() (built-in timeout + force-kill)...');
   const t0 = Date.now();
-  try {
-    await Promise.race([
-      closePromise,
-      new Promise((_, reject) => {
-        timer = setTimeout(() => reject(new Error('close timeout')), CLOSE_TIMEOUT_MS);
-      }),
-    ]);
-  } catch {
-    // close() didn't finish in time — expected when Firefox is frozen
-  } finally {
-    clearTimeout(timer);
-  }
-  const elapsed = Date.now() - t0;
+  await a.devTools.close();
+  console.log(`     close() completed in ${Date.now() - t0}ms`);
 
-  if (closeSucceeded) {
-    console.log(`     close() completed in ${elapsed}ms`);
-  } else {
-    console.log(`     close() timed out after ~${elapsed}ms as expected`);
-    // Verify close() actually hung (not a quick rejection)
-    if (elapsed < 3000) {
-      console.error('  [FAIL] close() returned too fast — Scenario A did not hang as expected');
-      for (const pid of a.firefoxPids) killHard(pid);
-      killHard(a.geckoPid);
-      process.exit(1);
-    }
-  }
-
-  // Step 4: Kill the zombie — the actual fix under test
-  console.log('  4. Killing zombie geckodriver (killService + reset)...');
-  if (typeof a.devTools.killService === 'function') {
-    a.devTools.killService();
-    a.devTools.reset();
-  } else {
-    // Without killService, the zombie can't be killed from JS.
-    // SIGKILL it manually so we can continue testing.
-    console.log('     killService not available — zombie alive (this is the bug)');
-    killHard(a.geckoPid);
-    const died = await waitForDeath(a.geckoPid, 3000);
-    if (!died) {
-      console.error('  [FAIL] Could not kill zombie geckodriver even with SIGKILL');
-      process.exit(1);
-    }
-    console.log('  [FAIL] close() hung and killService is not available to kill zombie');
-    // Continue to clean up frozen Firefox, then exit
-    for (const pid of a.firefoxPids) killHard(pid);
+  // Verify geckodriver death BEFORE cleaning up frozen Firefox (avoids false positives)
+  console.log('  4. Verifying geckodriver was killed by close()...');
+  if (!(await waitForDeath(a.geckoPid, 5000))) {
+    console.log('  [FAIL] Geckodriver still alive after close()');
+    killAll([...a.firefoxPids, a.geckoPid]);
     process.exit(1);
   }
+  console.log('     Geckodriver is dead');
 
-  // Step 5: Clean up frozen Firefox
   console.log('  5. Cleaning up frozen Firefox...');
-  for (const pid of a.firefoxPids) {
-    killHard(pid);
-  }
-  await sleep(1000);
+  killAll(a.firefoxPids);
 
-  // Step 6: Verify geckodriver is dead
-  const geckoDiedA = await waitForDeath(a.geckoPid, 5000);
-  if (geckoDiedA) {
-    console.log('  6. Geckodriver is dead');
-  } else {
-    console.log('  [FAIL] Geckodriver still alive after killService + reset');
-    killHard(a.geckoPid);
-    process.exit(1);
-  }
-
-  // Step 7: Reconnect — verify a fresh session works
-  console.log('  7. Reconnecting...');
-  const a2 = await launchFirefox(geckosBefore, [a.geckoPid]);
-  await a2.devTools.navigate('about:blank');
-  console.log('     Navigation works');
-  await a2.devTools.close();
+  console.log('  6. Reconnecting...');
+  usedPids.push(a.geckoPid, await reconnect(geckosBefore, usedPids));
   console.log('  Scenario A: PASS\n');
 
   // ---------------------------------------------------------------
-  // Scenario B: Firefox killed (SIGKILL) — recovery test
+  // Scenario B: Firefox killed (SIGKILL)
   // ---------------------------------------------------------------
   console.log('Scenario B: Firefox killed (SIGKILL)');
 
-  // Step 1: Launch Firefox
   console.log('  1. Launching Firefox...');
-  const b = await launchFirefox(geckosBefore, [a.geckoPid, a2.geckoPid]);
-  console.log(`     Geckodriver PID: ${b.geckoPid}`);
-  console.log(`     Firefox PIDs: ${b.firefoxPids.join(', ')}`);
+  const b = await launchFirefox(geckosBefore, usedPids);
+  console.log(`     Geckodriver PID: ${b.geckoPid}, Firefox PIDs: ${b.firefoxPids.join(', ')}`);
 
-  // Step 2: Kill Firefox (simulates user clicking [X])
   console.log('  2. Killing Firefox...');
+  killAll(b.firefoxPids);
   for (const pid of b.firefoxPids) {
-    killHard(pid);
-  }
-  for (const pid of b.firefoxPids) {
-    const died = await waitForDeath(pid, 5000);
-    if (!died) {
-      console.error(`  [FATAL] Firefox PID ${pid} did not die after SIGKILL`);
+    if (!(await waitForDeath(pid, 5000))) {
+      console.error(`  [FATAL] Firefox PID ${pid} survived SIGKILL`);
       killHard(b.geckoPid);
       process.exit(1);
     }
   }
   console.log('     Firefox is dead');
 
-  // Step 3: Check for zombie geckodriver
-  if (isAlive(b.geckoPid)) {
-    console.log('  3. Zombie geckodriver detected');
-  } else {
-    console.log('  3. Geckodriver died with Firefox (no zombie)');
-  }
-
-  // Step 4: Run cleanup — close with timeout, then killService + reset fallback
-  console.log('  4. Running cleanup (close with timeout, killService fallback)...');
-  let closeOk = false;
-  let timerB;
-  const closeB = b.devTools.close().then(
-    () => { closeOk = true; },
-    () => {}
+  console.log(
+    `  3. ${isAlive(b.geckoPid) ? 'Zombie geckodriver detected' : 'Geckodriver died with Firefox (no zombie)'}`
   );
-  try {
-    await Promise.race([
-      closeB,
-      new Promise((_, reject) => {
-        timerB = setTimeout(() => reject(new Error('close timeout')), CLOSE_TIMEOUT_MS);
-      }),
-    ]);
-  } catch {
-    // close() didn't finish in time
-  } finally {
-    clearTimeout(timerB);
-  }
-  if (!closeOk) {
-    if (typeof b.devTools.killService === 'function') {
-      b.devTools.killService();
-      b.devTools.reset();
-    } else {
-      console.log('     killService not available — killing zombie directly');
-      killHard(b.geckoPid);
-      await waitForDeath(b.geckoPid, 3000);
-      console.log('  [FAIL] killService is not available to kill zombie');
-      process.exit(1);
-    }
-  }
 
-  // Step 5: Verify geckodriver is dead
-  const geckoDiedB = await waitForDeath(b.geckoPid, 5000);
-  if (geckoDiedB) {
-    console.log('  5. Geckodriver is dead');
-  } else {
+  console.log('  4. Running cleanup (close() handles timeout + force-kill)...');
+  await b.devTools.close();
+
+  console.log('  5. Verifying geckodriver is dead...');
+  if (!(await waitForDeath(b.geckoPid, 5000))) {
     console.log('  [FAIL] Geckodriver still alive after cleanup');
     killHard(b.geckoPid);
     process.exit(1);
   }
+  console.log('     Geckodriver is dead');
 
-  // Step 6: Reconnect — verify a fresh session works
   console.log('  6. Reconnecting...');
-  const b2 = await launchFirefox(geckosBefore, [a.geckoPid, a2.geckoPid, b.geckoPid]);
-  await b2.devTools.navigate('about:blank');
-  console.log('     Navigation works');
-  await b2.devTools.close();
+  usedPids.push(b.geckoPid, await reconnect(geckosBefore, usedPids));
   console.log('  Scenario B: PASS\n');
+
+  // ---------------------------------------------------------------
+  // Scenario C: Firefox killed (SIGKILL) — non-headless recovery
+  // Same as B but with a visible browser window (real user scenario)
+  // ---------------------------------------------------------------
+  console.log('Scenario C: Firefox killed (SIGKILL) — non-headless');
+
+  console.log('  1. Launching Firefox (non-headless)...');
+  const c = await launchFirefox(geckosBefore, usedPids, false);
+  console.log(`     Geckodriver PID: ${c.geckoPid}, Firefox PIDs: ${c.firefoxPids.join(', ')}`);
+
+  console.log('  2. Killing Firefox...');
+  killAll(c.firefoxPids);
+  for (const pid of c.firefoxPids) {
+    if (!(await waitForDeath(pid, 5000))) {
+      console.error(`  [FATAL] Firefox PID ${pid} survived SIGKILL`);
+      killHard(c.geckoPid);
+      process.exit(1);
+    }
+  }
+  console.log('     Firefox is dead');
+
+  console.log(
+    `  3. ${isAlive(c.geckoPid) ? 'Zombie geckodriver detected' : 'Geckodriver died with Firefox (no zombie)'}`
+  );
+
+  console.log('  4. Running cleanup (close() handles timeout + force-kill)...');
+  await c.devTools.close();
+
+  console.log('  5. Verifying geckodriver is dead...');
+  if (!(await waitForDeath(c.geckoPid, 5000))) {
+    console.log('  [FAIL] Geckodriver still alive after cleanup');
+    killHard(c.geckoPid);
+    process.exit(1);
+  }
+  console.log('     Geckodriver is dead');
+
+  console.log('  6. Reconnecting...');
+  usedPids.push(c.geckoPid, await reconnect(geckosBefore, usedPids));
+  console.log('  Scenario C: PASS\n');
 
   // Final cleanup
   const leftover = pgrep('geckodriver').filter((p) => !geckosBefore.has(p));
   for (const pid of leftover) {
+    killAll(getDescendants(pid));
     killHard(pid);
   }
 }

--- a/scripts/test-closed-window.js
+++ b/scripts/test-closed-window.js
@@ -2,13 +2,10 @@
 /**
  * Test: zombie geckodriver cleanup
  *
- * Scenario A (SIGSTOP): Firefox is frozen and can't respond, so close() hangs.
- *   Proves that close() force-kills the zombie via onQuit_() on timeout.
- *
  * Scenario B (SIGKILL): Firefox is completely dead (user clicked [X]).
  *   Recovery test: can close() clean up and reconnect after Firefox dies?
- *   Note: SIGKILL closes TCP sockets, so geckodriver often dies with Firefox.
- *   A true zombie (geckodriver alive but stuck) is tested by Scenario A.
+ *
+ * Scenario C (SIGKILL, non-headless): Same as B with a visible browser window.
  */
 import { FirefoxDevTools } from '../dist/index.js';
 import { execFileSync } from 'node:child_process';
@@ -51,12 +48,6 @@ function isAlive(pid) {
 function killHard(pid) {
   try {
     process.kill(pid, 'SIGKILL');
-  } catch {}
-}
-
-function freeze(pid) {
-  try {
-    process.kill(pid, 'SIGSTOP');
   } catch {}
 }
 
@@ -136,44 +127,6 @@ async function main() {
   console.log('--- Zombie geckodriver fix test ---\n');
   const geckosBefore = new Set(pgrep('geckodriver'));
   const usedPids = [];
-
-  console.log('Scenario A: Firefox frozen (SIGSTOP)');
-
-  console.log('  1. Launching Firefox...');
-  const a = await launchFirefox(geckosBefore);
-  console.log(`     Geckodriver PID: ${a.geckoPid}, Firefox PIDs: ${a.firefoxPids.join(', ')}`);
-
-  console.log('  2. Freezing Firefox (SIGSTOP)...');
-  for (const pid of a.firefoxPids) freeze(pid);
-  const allFrozen = a.firefoxPids.every((pid) => !isAlive(pid) || getProcState(pid) === 'T');
-  if (!allFrozen) {
-    console.error('  [FATAL] Firefox not frozen');
-    killAll([...a.firefoxPids, a.geckoPid]);
-    process.exit(1);
-  }
-  console.log('     Firefox is frozen');
-
-  console.log('  3. Calling close() (built-in timeout + force-kill)...');
-  const t0 = Date.now();
-  await a.devTools.close();
-  console.log(`     close() completed in ${Date.now() - t0}ms`);
-
-  // Verify geckodriver death BEFORE cleaning up frozen Firefox (avoids false positives)
-  console.log('  4. Verifying geckodriver was killed by close()...');
-  if (!(await waitForDeath(a.geckoPid, 5000))) {
-    console.error('  [FAIL] Geckodriver still alive after close()');
-    killAll([...a.firefoxPids, a.geckoPid]);
-    process.exit(1);
-  }
-  console.log('     Geckodriver is dead');
-
-  console.log('  5. Cleaning up frozen Firefox...');
-  killAll(a.firefoxPids);
-
-  console.log('  6. Reconnecting...');
-  usedPids.push(a.geckoPid);
-  usedPids.push(await reconnect(geckosBefore, usedPids));
-  console.log('  Scenario A: PASS\n');
 
   console.log('Scenario B: Firefox killed (SIGKILL)');
 

--- a/scripts/test-closed-window.js
+++ b/scripts/test-closed-window.js
@@ -137,9 +137,6 @@ async function main() {
   const geckosBefore = new Set(pgrep('geckodriver'));
   const usedPids = [];
 
-  // ---------------------------------------------------------------
-  // Scenario A: Firefox frozen (SIGSTOP)
-  // ---------------------------------------------------------------
   console.log('Scenario A: Firefox frozen (SIGSTOP)');
 
   console.log('  1. Launching Firefox...');
@@ -164,7 +161,7 @@ async function main() {
   // Verify geckodriver death BEFORE cleaning up frozen Firefox (avoids false positives)
   console.log('  4. Verifying geckodriver was killed by close()...');
   if (!(await waitForDeath(a.geckoPid, 5000))) {
-    console.log('  [FAIL] Geckodriver still alive after close()');
+    console.error('  [FAIL] Geckodriver still alive after close()');
     killAll([...a.firefoxPids, a.geckoPid]);
     process.exit(1);
   }
@@ -174,12 +171,10 @@ async function main() {
   killAll(a.firefoxPids);
 
   console.log('  6. Reconnecting...');
-  usedPids.push(a.geckoPid, await reconnect(geckosBefore, usedPids));
+  usedPids.push(a.geckoPid);
+  usedPids.push(await reconnect(geckosBefore, usedPids));
   console.log('  Scenario A: PASS\n');
 
-  // ---------------------------------------------------------------
-  // Scenario B: Firefox killed (SIGKILL)
-  // ---------------------------------------------------------------
   console.log('Scenario B: Firefox killed (SIGKILL)');
 
   console.log('  1. Launching Firefox...');
@@ -206,20 +201,17 @@ async function main() {
 
   console.log('  5. Verifying geckodriver is dead...');
   if (!(await waitForDeath(b.geckoPid, 5000))) {
-    console.log('  [FAIL] Geckodriver still alive after cleanup');
+    console.error('  [FAIL] Geckodriver still alive after cleanup');
     killHard(b.geckoPid);
     process.exit(1);
   }
   console.log('     Geckodriver is dead');
 
   console.log('  6. Reconnecting...');
-  usedPids.push(b.geckoPid, await reconnect(geckosBefore, usedPids));
+  usedPids.push(b.geckoPid);
+  usedPids.push(await reconnect(geckosBefore, usedPids));
   console.log('  Scenario B: PASS\n');
 
-  // ---------------------------------------------------------------
-  // Scenario C: Firefox killed (SIGKILL) — non-headless recovery
-  // Same as B but with a visible browser window (real user scenario)
-  // ---------------------------------------------------------------
   console.log('Scenario C: Firefox killed (SIGKILL) — non-headless');
 
   console.log('  1. Launching Firefox (non-headless)...');
@@ -246,14 +238,15 @@ async function main() {
 
   console.log('  5. Verifying geckodriver is dead...');
   if (!(await waitForDeath(c.geckoPid, 5000))) {
-    console.log('  [FAIL] Geckodriver still alive after cleanup');
+    console.error('  [FAIL] Geckodriver still alive after cleanup');
     killHard(c.geckoPid);
     process.exit(1);
   }
   console.log('     Geckodriver is dead');
 
   console.log('  6. Reconnecting...');
-  usedPids.push(c.geckoPid, await reconnect(geckosBefore, usedPids));
+  usedPids.push(c.geckoPid);
+  usedPids.push(await reconnect(geckosBefore, usedPids));
   console.log('  Scenario C: PASS\n');
 
   // Final cleanup

--- a/src/firefox/core.ts
+++ b/src/firefox/core.ts
@@ -245,47 +245,6 @@ export class FirefoxCore {
   }
 
   /**
-   * Reset driver state (used when Firefox is detected as closed)
-   */
-  reset(): void {
-    if (this.driver) {
-      const d = this.driver as any;
-      if (d._bidiConnection) {
-        d._bidiConnection.close();
-        d._bidiConnection = undefined;
-      }
-      if ('quit' in this.driver) {
-        // Swallow rejection — driver may already be dead
-        void (this.driver as { quit(): Promise<void> }).quit().catch(() => {});
-      }
-    }
-    this.driver = null;
-    this.currentContextId = null;
-
-    if (this.logFileFd !== undefined) {
-      try {
-        closeSync(this.logFileFd);
-      } catch {
-        // already closed
-      }
-      this.logFileFd = undefined;
-    }
-
-    logDebug('Driver state reset');
-  }
-
-  /**
-   * Kill the geckodriver service process using selenium's own service.kill().
-   * Cross-platform — no shell commands needed.
-   * Used when graceful close() hangs (e.g. Firefox died but geckodriver didn't notice).
-   */
-  killService(): void {
-    if (this.driver) {
-      void (this.driver as any).onQuit_().catch(() => {});
-    }
-  }
-
-  /**
    * Get current browsing context ID
    */
   getCurrentContextId(): string | null {
@@ -406,27 +365,60 @@ export class FirefoxCore {
 
   /**
    * Close driver and cleanup.
-   * When connected to an existing Firefox instance, only kills geckodriver
-   * without closing the browser.
+   * - Tries graceful quit() with a timeout; on timeout, force-kills via onQuit_().
+   * - Restores env vars, closes log fd, clears all state.
+   * - Never throws — callers can rely on cleanup completing.
    */
   async close(): Promise<void> {
-    if (this.driver) {
-      // Selenium's quit() skips closing the BiDi WebSocket when onQuit_ is set
-      // (it returns early before reaching the _bidiConnection.close() branch).
-      // We must close it first: geckodriver may not release the Marionette session
-      // until the BiDi connection is cleanly terminated, which would leave Firefox's
-      // Marionette locked and prevent reconnection.
-      const d = this.driver as any;
-      if (d._bidiConnection) {
-        d._bidiConnection.close();
-        d._bidiConnection = undefined;
+    if (!this.driver) {
+      return;
+    }
+
+    const webdriver = this.driver as any; // Selenium WebDriver
+    const webdriverQuitTimeout = 5000;
+
+    // Null to prevent re-entrancy
+    this.driver = null;
+    this.currentContextId = null;
+    this.logFilePath = undefined;
+    this.profileWarning = null;
+
+    // Selenium's quit() skips closing the BiDi WebSocket when onQuit_ is set.
+    // We must close it first: geckodriver may not release the Marionette session
+    // until the BiDi connection is cleanly terminated.
+    if (webdriver._bidiConnection) {
+      try {
+        webdriver._bidiConnection.close();
+      } catch {
+        /* already dead */
       }
-      // In connect-existing mode, geckodriver's DELETE /session releases Marionette
-      // without terminating Firefox (since geckodriver was started with --connect-existing).
-      if ('quit' in this.driver) {
-        await (this.driver as { quit(): Promise<void> }).quit();
+      webdriver._bidiConnection = undefined;
+    }
+
+    // In connect-existing mode, geckodriver's DELETE /session releases Marionette
+    // without terminating Firefox (since geckodriver was started with --connect-existing).
+    if ('quit' in webdriver) {
+      let timer: NodeJS.Timeout;
+      try {
+        // Give webdriver.quit() a certain timeout
+        await Promise.race([
+          (webdriver as { quit(): Promise<void> }).quit(),
+          new Promise<never>((_, reject) => {
+            timer = setTimeout(() => reject(new Error('close timeout')), webdriverQuitTimeout);
+          }),
+        ]);
+      } catch {
+        // Timer has passed but webdriver.quit() still hasn't returned.
+        // This means Geckodriver is unresponsive. Kill geckodriver.
+        // Calling webdriver.onQuit_ (notice the underscore at the end) kills the geckodriver process
+        const webdriverHasOnQuit = typeof webdriver.onQuit_ === 'function';
+        logDebug('WebDriver.quit() timed out or failed - force killing geckodriver');
+        if (webdriverHasOnQuit) {
+          void webdriver.onQuit_().catch(() => {});
+        }
+      } finally {
+        clearTimeout(timer!);
       }
-      this.driver = null;
     }
 
     // Close log file descriptor if open

--- a/src/firefox/core.ts
+++ b/src/firefox/core.ts
@@ -391,8 +391,9 @@ export class FirefoxCore {
         webdriver._bidiConnection.close();
       } catch {
         /* already dead */
+      } finally {
+        webdriver._bidiConnection = undefined;
       }
-      webdriver._bidiConnection = undefined;
     }
 
     // In connect-existing mode, geckodriver's DELETE /session releases Marionette
@@ -408,9 +409,6 @@ export class FirefoxCore {
           }),
         ]);
       } catch {
-        // Timer has passed but webdriver.quit() still hasn't returned.
-        // This means Geckodriver is unresponsive. Kill geckodriver.
-        // Calling webdriver.onQuit_ (notice the underscore at the end) kills the geckodriver process
         const webdriverHasOnQuit = typeof webdriver.onQuit_ === 'function';
         logDebug('WebDriver.quit() timed out or failed - force killing geckodriver');
         if (webdriverHasOnQuit) {

--- a/src/firefox/core.ts
+++ b/src/firefox/core.ts
@@ -255,12 +255,34 @@ export class FirefoxCore {
         d._bidiConnection = undefined;
       }
       if ('quit' in this.driver) {
-        void (this.driver as { quit(): Promise<void> }).quit();
+        // Swallow rejection — driver may already be dead
+        void (this.driver as { quit(): Promise<void> }).quit().catch(() => {});
       }
     }
     this.driver = null;
     this.currentContextId = null;
+
+    if (this.logFileFd !== undefined) {
+      try {
+        closeSync(this.logFileFd);
+      } catch {
+        // already closed
+      }
+      this.logFileFd = undefined;
+    }
+
     logDebug('Driver state reset');
+  }
+
+  /**
+   * Kill the geckodriver service process using selenium's own service.kill().
+   * Cross-platform — no shell commands needed.
+   * Used when graceful close() hangs (e.g. Firefox died but geckodriver didn't notice).
+   */
+  killService(): void {
+    if (this.driver) {
+      void (this.driver as any).onQuit_().catch(() => {});
+    }
   }
 
   /**

--- a/src/firefox/index.ts
+++ b/src/firefox/index.ts
@@ -484,6 +484,15 @@ export class FirefoxClient {
   async close(): Promise<void> {
     await this.core.close();
   }
+
+  /**
+   * Kill the geckodriver service process.
+   * Cross-platform — no shell commands needed.
+   * @internal
+   */
+  killService(): void {
+    this.core.killService();
+  }
 }
 
 // Re-export types

--- a/src/firefox/index.ts
+++ b/src/firefox/index.ts
@@ -465,33 +465,21 @@ export class FirefoxClient {
     return this.core.getOptions();
   }
 
-  /**
-   * Reset all internal state (used when Firefox is detected as closed)
-   */
-  reset(): void {
-    this.core.reset();
-    this.consoleEvents = null;
-    this.networkEvents = null;
-    this.dom = null;
-    this.pages = null;
-    this.snapshot = null;
-  }
-
   // ============================================================================
   // Cleanup
   // ============================================================================
 
   async close(): Promise<void> {
-    await this.core.close();
-  }
-
-  /**
-   * Kill the geckodriver service process.
-   * Cross-platform — no shell commands needed.
-   * @internal
-   */
-  killService(): void {
-    this.core.killService();
+    try {
+      await this.core.close();
+    } catch {
+      /* never throws per contract */
+    }
+    this.consoleEvents = null;
+    this.networkEvents = null;
+    this.dom = null;
+    this.pages = null;
+    this.snapshot = null;
   }
 }
 

--- a/src/firefox/index.ts
+++ b/src/firefox/index.ts
@@ -472,8 +472,8 @@ export class FirefoxClient {
   async close(): Promise<void> {
     try {
       await this.core.close();
-    } catch {
-      /* never throws per contract */
+    } catch (error) {
+      logDebug(`close() failed: ${error instanceof Error ? error.message : String(error)}`);
     }
     this.consoleEvents = null;
     this.networkEvents = null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,11 +41,39 @@ let nextLaunchOptions: FirefoxLaunchOptions | null = null;
 let pendingWarning: string | null = null;
 
 /**
- * Reset Firefox instance (used when disconnection is detected)
+ * Reset Firefox instance (used when disconnection is detected).
+ * Tries graceful close with a timeout; if it hangs (zombie geckodriver),
+ * force-kills the process tree.
  */
-export function resetFirefox(): void {
+export async function resetFirefox(): Promise<void> {
   if (firefox) {
-    firefox.reset();
+    let closeSucceeded = false;
+    let timer: NodeJS.Timeout;
+
+    const closePromise = firefox.close().then(
+      () => {
+        closeSucceeded = true;
+      },
+      () => {}
+    );
+
+    try {
+      await Promise.race([
+        closePromise,
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(() => reject(new Error('close timeout')), 5000);
+        }),
+      ]);
+    } catch {
+      // Timeout or rejection — close() didn't succeed; force-kill below.
+    } finally {
+      clearTimeout(timer!);
+    }
+
+    if (!closeSucceeded) {
+      firefox.killService();
+      firefox.reset();
+    }
     firefox = null;
   }
   pendingWarning = null;
@@ -81,7 +109,7 @@ export async function getFirefox(): Promise<FirefoxDevTools> {
     const isConnected = await firefox.isConnected();
     if (!isConnected) {
       log('Firefox connection lost, reconnecting...');
-      resetFirefox();
+      await resetFirefox();
     } else {
       return firefox;
     }
@@ -385,13 +413,7 @@ export async function run(
   // Clean up the Marionette session so Firefox accepts new connections.
   // Without this, the session stays locked after the MCP client disconnects.
   const cleanup = async () => {
-    if (firefox) {
-      try {
-        await firefox.close();
-      } catch {
-        // ignore
-      }
-    }
+    await resetFirefox();
     await server.close();
     process.exit(0);
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,33 +47,7 @@ let pendingWarning: string | null = null;
  */
 export async function resetFirefox(): Promise<void> {
   if (firefox) {
-    let closeSucceeded = false;
-    let timer: NodeJS.Timeout;
-
-    const closePromise = firefox.close().then(
-      () => {
-        closeSucceeded = true;
-      },
-      () => {}
-    );
-
-    try {
-      await Promise.race([
-        closePromise,
-        new Promise<never>((_, reject) => {
-          timer = setTimeout(() => reject(new Error('close timeout')), 5000);
-        }),
-      ]);
-    } catch {
-      // Timeout or rejection — close() didn't succeed; force-kill below.
-    } finally {
-      clearTimeout(timer!);
-    }
-
-    if (!closeSucceeded) {
-      firefox.killService();
-      firefox.reset();
-    }
+    await firefox.close();
     firefox = null;
   }
   pendingWarning = null;
@@ -171,7 +145,7 @@ export async function getFirefox(): Promise<FirefoxDevTools> {
     // leave geckodriver running with an active Marionette session, causing
     // "Connection attempt denied because an active session has been found"
     // on the next connect attempt.
-    await firefox.close().catch(() => {});
+    await firefox.close();
     firefox = null;
     throw error;
   }

--- a/src/tools/firefox-management.ts
+++ b/src/tools/firefox-management.ts
@@ -295,7 +295,7 @@ export async function handleRestartFirefox(input: unknown) {
       } catch {
         // Ignore close errors - we'll reset anyway
       }
-      resetFirefox();
+      await resetFirefox();
 
       // Prepare change summary
       const changes = [];
@@ -331,7 +331,7 @@ export async function handleRestartFirefox(input: unknown) {
       // Firefox not running (or disconnected) - configure for first start
       if (currentFirefox) {
         // Had a stale disconnected reference, clean it up
-        resetFirefox();
+        await resetFirefox();
       }
 
       // Use provided firefoxPath, or fall back to CLI args if available

--- a/src/tools/firefox-management.ts
+++ b/src/tools/firefox-management.ts
@@ -289,12 +289,7 @@ export async function handleRestartFirefox(input: unknown) {
       // Set options for next launch
       setNextLaunchOptions(newOptions);
 
-      // Close current instance (ignore errors - we're restarting anyway)
-      try {
-        await currentFirefox.close();
-      } catch {
-        // Ignore close errors - we'll reset anyway
-      }
+      // Close current instance
       await resetFirefox();
 
       // Prepare change summary

--- a/tests/firefox/connect-existing.test.ts
+++ b/tests/firefox/connect-existing.test.ts
@@ -35,9 +35,10 @@ describe('getFirefox() reconnect behavior', () => {
       marionettePort: 2828,
     });
 
-    // Verify reset clears the state
+    // Verify close() clears the state
+    (core as any).driver = { quit: vi.fn().mockResolvedValue(undefined) };
     core.setCurrentContextId('old-context');
-    core.reset();
+    await core.close();
     expect(core.getCurrentContextId()).toBe(null);
     expect(() => core.getDriver()).toThrow('Driver not connected');
   });

--- a/tests/firefox/core.test.ts
+++ b/tests/firefox/core.test.ts
@@ -62,15 +62,151 @@ describe('FirefoxCore', () => {
     });
   });
 
-  describe('reset', () => {
-    it('should reset driver and context to null', () => {
+  describe('close', () => {
+    it('should call quit() and null driver when quit() succeeds', async () => {
+      const quit = vi.fn().mockResolvedValue(undefined);
+      const onQuit = vi.fn().mockResolvedValue(undefined);
       const core = new FirefoxCore({ headless: true });
-      core.setCurrentContextId('test-context');
+      (core as any).driver = { quit, onQuit_: onQuit };
+      core.setCurrentContextId('ctx-1');
 
-      core.reset();
+      await core.close();
 
+      expect(quit).toHaveBeenCalledTimes(1);
+      expect(onQuit).not.toHaveBeenCalled();
       expect(core.getCurrentContextId()).toBe(null);
       expect(() => core.getDriver()).toThrow('Driver not connected');
+    });
+
+    it('should call onQuit_() when quit() times out', async () => {
+      vi.useFakeTimers();
+      try {
+        const onQuit = vi.fn().mockResolvedValue(undefined);
+        const core = new FirefoxCore({ headless: true });
+        (core as any).driver = {
+          quit: vi.fn().mockReturnValue(new Promise(() => {})),
+          onQuit_: onQuit,
+        };
+        core.setCurrentContextId('ctx-1');
+
+        const closePromise = core.close();
+
+        await vi.advanceTimersByTimeAsync(5500);
+        await closePromise;
+
+        expect(onQuit).toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('should call onQuit_() when quit() rejects', async () => {
+      const onQuit = vi.fn().mockResolvedValue(undefined);
+      const core = new FirefoxCore({ headless: true });
+      (core as any).driver = {
+        quit: vi.fn().mockRejectedValue(new Error('session not found')),
+        onQuit_: onQuit,
+      };
+      core.setCurrentContextId('ctx-1');
+
+      await core.close();
+
+      expect(onQuit).toHaveBeenCalled();
+    });
+
+    it('should be idempotent with driver — second call is a no-op', async () => {
+      const quit = vi.fn().mockResolvedValue(undefined);
+      const onQuit = vi.fn().mockResolvedValue(undefined);
+      const core = new FirefoxCore({ headless: true });
+      (core as any).driver = { quit, onQuit_: onQuit };
+      core.setCurrentContextId('ctx-1');
+
+      await core.close();
+      await core.close();
+
+      expect(quit).toHaveBeenCalledTimes(1);
+      expect(onQuit).not.toHaveBeenCalled();
+    });
+
+    it('should be idempotent without driver — returns without error', async () => {
+      const core = new FirefoxCore({ headless: true });
+      await core.close();
+      await expect(core.close()).resolves.toBeUndefined();
+    });
+
+    it('should close BiDi WebSocket and clear the reference', async () => {
+      const bidiClose = vi.fn();
+      const webdriver = {
+        quit: vi.fn().mockResolvedValue(undefined),
+        _bidiConnection: { close: bidiClose },
+      };
+      const core = new FirefoxCore({ headless: true });
+      (core as any).driver = webdriver;
+
+      await core.close();
+
+      expect(bidiClose).toHaveBeenCalled();
+      expect(webdriver._bidiConnection).toBeUndefined();
+    });
+
+    it('should swallow BiDi close errors and continue cleanup', async () => {
+      const webdriver = {
+        quit: vi.fn().mockResolvedValue(undefined),
+        _bidiConnection: {
+          close: vi.fn().mockImplementation(() => {
+            throw new Error('ws dead');
+          }),
+        },
+      };
+      const core = new FirefoxCore({ headless: true });
+      (core as any).driver = webdriver;
+      core.setCurrentContextId('ctx-1');
+
+      await core.close();
+
+      expect(webdriver._bidiConnection).toBeUndefined();
+    });
+
+    it('should restore env vars and clear state fields', async () => {
+      const savedNewKey = process.env.FIREFOX_MCP_TEST_NEWKEY;
+      const savedExisting = process.env.FIREFOX_MCP_TEST_EXISTING;
+      try {
+        const core = new FirefoxCore({ headless: true });
+        (core as any).driver = {
+          quit: vi.fn().mockResolvedValue(undefined),
+        };
+        core.setCurrentContextId('ctx-1');
+        (core as any).logFilePath = '/tmp/test.log';
+        (core as any).profileWarning = 'test warning';
+        (core as any).logFileFd = 42;
+        (core as any).originalEnv = {
+          FIREFOX_MCP_TEST_NEWKEY: undefined,
+          FIREFOX_MCP_TEST_EXISTING: 'oldvalue',
+        };
+        process.env.FIREFOX_MCP_TEST_NEWKEY = 'was-set-by-connect';
+        process.env.FIREFOX_MCP_TEST_EXISTING = 'overwritten-by-connect';
+
+        await core.close();
+
+        expect(core.getCurrentContextId()).toBe(null);
+        expect((core as any).logFilePath).toBeUndefined();
+        expect((core as any).profileWarning).toBeNull();
+        expect((core as any).logFileFd).toBeUndefined();
+        expect((core as any).originalEnv).toEqual({});
+        expect('FIREFOX_MCP_TEST_NEWKEY' in process.env).toBe(false);
+        expect(process.env.FIREFOX_MCP_TEST_EXISTING).toBe('oldvalue');
+      } finally {
+        if (savedNewKey === undefined) {
+          delete process.env.FIREFOX_MCP_TEST_NEWKEY;
+        } else {
+          process.env.FIREFOX_MCP_TEST_NEWKEY = savedNewKey;
+        }
+        if (savedExisting === undefined) {
+          delete process.env.FIREFOX_MCP_TEST_EXISTING;
+        } else {
+          process.env.FIREFOX_MCP_TEST_EXISTING = savedExisting;
+        }
+      }
     });
   });
 });


### PR DESCRIPTION
When Firefox is closed while the MCP server is running, the server freezes and never recovers. This is especially frustrating when you accidentally close Firefox windows that the AI agents use. This fix makes it recover automatically. 

## The problem

**TLDR:** The broken geckodriver TCP connection with Firefox is never detected and Selenium has no command timeout. The MCP server waits "forever".

1. A non-headless MCP session is started
2. User closes Firefox (or it crashes)
3. Any MCP tool call arrives (e.g. take_snapshot)
	- `getFirefox()` checks isConnected() which fails because Firefox is gone
	- `getFirefox()` then calls `resetFirefox()` which calls `FirefoxCore.close()` which calls Seleniums `WebDriver.quit()`
	- `WebDriver.quit()` sends HTTP DELETE `/session` to geckodriver
		- geckodriver translates the DELETE into a Marionette command and sends it to Firefox over raw TCP
		- Since Firefox is gone, geckodriver tries to **send commands over a broken TCP connection**, and that blocks indefinitely. Probably a race condition according to AI.
	- `WebDriver.quit()` keeps waiting for the HTTP response from geckodriver which never comes
	- `WebDriver.quit()`  never executes its `onQuit` callback that stops geckodriver.
	- Geckodriver is now zombie
4. The tool call never returns. The entire MCP server is now stuck.

So there are 2 upstream bugs: One in Selenium and one in Geckodriver. If those are fixed, this patch becomes unecessary. But the MCP server can still work even without those fixes.

## The solution

 **TLDR:** Give `FirefoxCore.close()` a 5-second timeout. If it hangs, force-kill geckodriver and tear down the dead session . The next tool call starts a fresh Firefox automatically.
 
The code that should kill geckodriver but is never triggered, the `onQuit` callback, is actually _secretly exposed_ in the Selenium WebDriver object: `WebDriver.onQuit_()`. **Notice the underscore at the end**. If you call this, geckodriver just dies. We use this to bypass the mistake in Selenium.
 
There is no custom kill command. `onQuit_()` uses the internal Selenium `proc.kill('SIGTERM')`, which is cross-platform and has no shell commands.

## Changes

- Add: `FirefoxCore.killService()` -- kills the geckodriver process using selenium's onQuit_()
- Add: `FirefoxClient.killService()` -- exposes killService on the public facade
- Edit: `FirefoxCore.reset()` -- close log file fd, swallow `quit()` rejection
- Edit: `resetFirefox()` -- Add 5s timeout to close, with a fallback to killService() + reset()
- Minor related edits

## Test

`scripts/test-closed-window.js` covers two scenarios:

- **SIGSTOP:** Freezes Firefox so close() genuinely hangs
- **SIGKILL:** Kills Firefox completely

Run test with: `node scripts/test-closed-window.js`