### PR TITLE
Fix moz-extension:// navigation hang by bypassing geckodriver

### DIFF
--- a/src/firefox/index.ts
+++ b/src/firefox/index.ts
@@ -74,7 +74,8 @@ export class FirefoxClient {
     this.pages = new PageManagement(
       driver,
       () => this.core.getCurrentContextId(),
-      (id: string) => this.core.setCurrentContextId(id)
+      (id: string) => this.core.setCurrentContextId(id),
+      (method: string, params: Record<string, any>) => this.core.sendBiDiCommand(method, params)
     );
 
     // Subscribe to console and network events for ALL contexts (not just current).

--- a/src/firefox/pages.ts
+++ b/src/firefox/pages.ts
@@ -7,7 +7,11 @@ import { log, logDebug } from '../utils/logger.js';
 
 const PRIVILEGED_URL_SCHEMES = ['moz-extension:'];
 
-function isPrivilegedUrl(url: string): boolean {
+/**
+ * Check if a URL uses a privileged scheme that requires BiDi navigation.
+ * @internal Exported for testability only; not a stable public API.
+ */
+export function isPrivilegedUrl(url: string): boolean {
   try {
     return PRIVILEGED_URL_SCHEMES.includes(new URL(url).protocol);
   } catch {

--- a/src/firefox/pages.ts
+++ b/src/firefox/pages.ts
@@ -5,51 +5,51 @@
 import { WebDriver } from 'selenium-webdriver';
 import { log, logDebug } from '../utils/logger.js';
 
-const PRIVILEGED_URL_SCHEMES = ['moz-extension:'];
+const COMMON_URL_SCHEMES = ['http:', 'https:', 'data:', 'blob:', 'file:'];
 
 /**
- * Check if a URL uses a privileged scheme that requires BiDi navigation.
- * @internal Exported for testability only; not a stable public API.
+ * Check if a URL uses a common scheme that supports load events.
+ * Non-common schemes = moz-extension:, about:, ...
  */
-export function isPrivilegedUrl(url: string): boolean {
+export function isCommonScheme(url: string): boolean {
   try {
-    return PRIVILEGED_URL_SCHEMES.includes(new URL(url).protocol);
+    return COMMON_URL_SCHEMES.includes(new URL(url).protocol);
   } catch {
-    logDebug(`URL parse failed, treating as non-privileged: ${url}`);
     return false;
   }
 }
+
+export type BiDiCommandFn = (method: string, params: Record<string, any>) => Promise<any>;
 
 export class PageManagement {
   constructor(
     private driver: WebDriver,
     private getCurrentContextId: () => string | null,
     private setCurrentContextId: (id: string) => void,
-    private sendBiDiCommand?: (method: string, params: Record<string, any>) => Promise<any>
+    private sendBiDiCommand: BiDiCommandFn
   ) {}
 
   /**
-   * Navigate to URL.
-   * For moz-extension:// URLs, uses BiDi browsingContext.navigate with
-   * wait:"none" because geckodriver
-   * waits for BiDi navigation completion events that the Remote Agent does
-   * not emit for extension/privileged contexts, causing driver.get() to hang.
+   * Navigate to URL using BiDi
    */
   async navigate(url: string): Promise<void> {
-    if (isPrivilegedUrl(url) && this.sendBiDiCommand) {
-      const contextId = this.getCurrentContextId();
-      if (!contextId) {
-        throw new Error(`Cannot navigate to privileged URL ${url}: no browsing context ID`);
-      }
-      await this.sendBiDiCommand('browsingContext.navigate', {
-        context: contextId,
-        url,
-        wait: 'none',
-      });
-      logDebug(`BiDi navigate (wait:none) to: ${url}`);
-    } else {
-      await this.driver.get(url);
+    const contextId = this.getCurrentContextId();
+    if (!contextId) {
+      throw new Error(`Cannot navigate: no browsing context ID`);
     }
+
+    // Default wait time is "interactive" (DOMContentLoaded).
+    // All uncommon schemes use wait time "none"
+    const wait = isCommonScheme(url) ? 'interactive' : 'none';
+
+    // Navigate using direct BiDi
+    await this.sendBiDiCommand('browsingContext.navigate', {
+      context: contextId,
+      url,
+      wait,
+    });
+
+    logDebug(`BiDi navigate (wait:${wait}) to: ${url}`);
     log(`Navigated to: ${url}`);
   }
 

--- a/src/firefox/pages.ts
+++ b/src/firefox/pages.ts
@@ -3,20 +3,49 @@
  */
 
 import { WebDriver } from 'selenium-webdriver';
-import { log } from '../utils/logger.js';
+import { log, logDebug } from '../utils/logger.js';
+
+const PRIVILEGED_URL_SCHEMES = ['moz-extension:'];
+
+function isPrivilegedUrl(url: string): boolean {
+  try {
+    return PRIVILEGED_URL_SCHEMES.includes(new URL(url).protocol);
+  } catch {
+    logDebug(`URL parse failed, treating as non-privileged: ${url}`);
+    return false;
+  }
+}
 
 export class PageManagement {
   constructor(
     private driver: WebDriver,
     private getCurrentContextId: () => string | null,
-    private setCurrentContextId: (id: string) => void
+    private setCurrentContextId: (id: string) => void,
+    private sendBiDiCommand?: (method: string, params: Record<string, any>) => Promise<any>
   ) {}
 
   /**
-   * Navigate to URL
+   * Navigate to URL.
+   * For moz-extension:// URLs, uses BiDi browsingContext.navigate with
+   * wait:"none" because geckodriver
+   * waits for BiDi navigation completion events that the Remote Agent does
+   * not emit for extension/privileged contexts, causing driver.get() to hang.
    */
   async navigate(url: string): Promise<void> {
-    await this.driver.get(url);
+    if (isPrivilegedUrl(url) && this.sendBiDiCommand) {
+      const contextId = this.getCurrentContextId();
+      if (!contextId) {
+        throw new Error(`Cannot navigate to privileged URL ${url}: no browsing context ID`);
+      }
+      await this.sendBiDiCommand('browsingContext.navigate', {
+        context: contextId,
+        url,
+        wait: 'none',
+      });
+      logDebug(`BiDi navigate (wait:none) to: ${url}`);
+    } else {
+      await this.driver.get(url);
+    }
     log(`Navigated to: ${url}`);
   }
 
@@ -159,7 +188,7 @@ export class PageManagement {
     const newIdx = handles.length - 1;
     this.setCurrentContextId(handles[newIdx]!);
     this.cachedSelectedIdx = newIdx;
-    await this.driver.get(url);
+    await this.navigate(url);
     return newIdx;
   }
 

--- a/tests/firefox/pages.test.ts
+++ b/tests/firefox/pages.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Unit tests for PageManagement and isPrivilegedUrl
+ *
+ * The moz-extension:// fix: geckodriver's driver.get() hangs on extension URLs
+ * because it waits for BiDi navigation completion events that the Remote Agent
+ * never emits for extension contexts. The fix routes moz-extension:// URLs
+ * through BiDi browsingContext.navigate with wait:"none", which returns
+ * immediately without waiting for load events.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { isPrivilegedUrl, PageManagement } from '@/firefox/pages.js';
+
+// -- isPrivilegedUrl ----------------------------------------------------------
+
+describe('isPrivilegedUrl', () => {
+  it('returns true for moz-extension:// URLs', () => {
+    expect(isPrivilegedUrl('moz-extension://abc123/popup.html')).toBe(true);
+  });
+
+  it('returns false for https:// URLs', () => {
+    expect(isPrivilegedUrl('https://example.com')).toBe(false);
+  });
+
+  it('returns false for http:// URLs', () => {
+    expect(isPrivilegedUrl('http://localhost:3000')).toBe(false);
+  });
+
+  it('returns false for file:// URLs', () => {
+    expect(isPrivilegedUrl('file:///path/to/page.html')).toBe(false);
+  });
+
+  it('returns false for about: URLs (not in PRIVILEGED_URL_SCHEMES)', () => {
+    expect(isPrivilegedUrl('about:blank')).toBe(false);
+  });
+
+  // Malformed strings make URL constructor throw; the catch block returns false
+  it('returns false for malformed URLs', () => {
+    expect(isPrivilegedUrl('not-a-url')).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    expect(isPrivilegedUrl('')).toBe(false);
+  });
+});
+
+// -- PageManagement -----------------------------------------------------------
+
+describe('PageManagement', () => {
+  type BiDiCommandFn = (method: string, params: Record<string, any>) => Promise<any>;
+
+  /**
+   * Build mocked PageManagement dependencies.
+   *
+   * The contextId handling is subtle: null and undefined mean different things.
+   * - contextId: null   → explicitly null (no browsing context available)
+   * - contextId omitted → defaults to 'ctx-1' (normal case)
+   *
+   * We use `'contextId' in overrides` to distinguish these, because
+   * `null ?? 'ctx-1'` would incorrectly collapse null into the default.
+   */
+  function createMocks(overrides?: { contextId?: string | null; sendBiDiCommand?: BiDiCommandFn }) {
+    const driver = { get: vi.fn().mockResolvedValue(undefined) } as any;
+    const hasContextId = 'contextId' in (overrides ?? {});
+    const contextId = hasContextId ? overrides!.contextId : 'ctx-1';
+    const getCurrentContextId = vi.fn().mockImplementation(() => contextId);
+    const setCurrentContextId = vi.fn();
+
+    // When sendBiDiCommand is provided, wrap it in a mock so we can assert calls.
+    // When omitted, it stays undefined — simulates BiDi being unavailable.
+    const sendBiDiCommand = overrides?.sendBiDiCommand
+      ? vi.fn().mockImplementation(overrides.sendBiDiCommand)
+      : undefined;
+
+    const pages = new PageManagement(driver, getCurrentContextId, setCurrentContextId, sendBiDiCommand as any);
+    return { pages, driver, getCurrentContextId, setCurrentContextId, sendBiDiCommand: sendBiDiCommand as any };
+  }
+
+  describe('navigate', () => {
+    // Core fix: moz-extension:// must use BiDi, not driver.get()
+    it('uses BiDi browsingContext.navigate with wait:none for moz-extension:// URLs', async () => {
+      const bidiFn = vi.fn().mockResolvedValue({});
+      const { pages, driver, sendBiDiCommand } = createMocks({ sendBiDiCommand: bidiFn });
+
+      await pages.navigate('moz-extension://abc123/popup.html');
+
+      expect(sendBiDiCommand).toHaveBeenCalledWith('browsingContext.navigate', {
+        context: 'ctx-1',
+        url: 'moz-extension://abc123/popup.html',
+        wait: 'none',
+      });
+      expect(driver.get).not.toHaveBeenCalled();
+    });
+
+    // Guard: no context ID means we can't send a BiDi command.
+    // Also verify sendBiDiCommand was never called (not just that it threw).
+    it('throws when context ID is null for moz-extension:// URL', async () => {
+      const bidiFn = vi.fn().mockResolvedValue({});
+      const { pages, sendBiDiCommand } = createMocks({ contextId: null, sendBiDiCommand: bidiFn });
+
+      await expect(pages.navigate('moz-extension://abc123/popup.html')).rejects.toThrow(
+        'Cannot navigate to privileged URL moz-extension://abc123/popup.html: no browsing context ID'
+      );
+      expect(sendBiDiCommand).not.toHaveBeenCalled();
+    });
+
+    // Fallback: if BiDi is not available (e.g. no Remote Agent), we still try
+    // driver.get(). This will hang for moz-extension://, but there's no alternative.
+    it('falls through to driver.get() for moz-extension:// when BiDi is unavailable', async () => {
+      const { pages, driver, sendBiDiCommand } = createMocks();
+
+      await pages.navigate('moz-extension://abc123/popup.html');
+
+      expect(driver.get).toHaveBeenCalledWith('moz-extension://abc123/popup.html');
+      expect(sendBiDiCommand).toBeUndefined();
+    });
+
+    // Non-privileged URLs always use the standard path
+    it('uses driver.get() for normal URLs', async () => {
+      const bidiFn = vi.fn().mockResolvedValue({});
+      const { pages, driver, sendBiDiCommand } = createMocks({ sendBiDiCommand: bidiFn });
+
+      await pages.navigate('https://example.com');
+
+      expect(driver.get).toHaveBeenCalledWith('https://example.com');
+      expect(sendBiDiCommand).not.toHaveBeenCalled();
+    });
+
+    // If the BiDi command rejects, the error should propagate (no silent swallow)
+    it('propagates BiDi navigation errors for moz-extension:// URLs', async () => {
+      const bidiFn = vi.fn().mockRejectedValue(new Error('BiDi error: invalid context'));
+      const { pages } = createMocks({ sendBiDiCommand: bidiFn });
+
+      await expect(pages.navigate('moz-extension://abc123/popup.html')).rejects.toThrow(
+        'BiDi error: invalid context'
+      );
+    });
+  });
+
+  describe('createNewPage', () => {
+    // createNewPage must delegate to navigate(), not call driver.get() directly,
+    // so that the moz-extension:// BiDi path is also used for new tabs
+    it('uses BiDi navigate for moz-extension:// URL after creating the tab', async () => {
+      const bidiFn = vi.fn().mockResolvedValue({});
+      const allHandles = ['handle-1', 'handle-2'];
+      const driver = {
+        get: vi.fn().mockResolvedValue(undefined),
+        switchTo: vi.fn().mockReturnValue({ newWindow: vi.fn().mockResolvedValue(undefined) }),
+        getAllWindowHandles: vi.fn().mockResolvedValue(allHandles),
+      } as any;
+      const getCurrentContextId = vi.fn().mockReturnValue('handle-2');
+      const setCurrentContextId = vi.fn();
+
+      const pages = new PageManagement(driver, getCurrentContextId, setCurrentContextId, bidiFn as any);
+
+      const idx = await pages.createNewPage('moz-extension://abc123/popup.html');
+
+      // Verify the BiDi navigate was used (not driver.get)
+      expect(bidiFn).toHaveBeenCalledWith('browsingContext.navigate', {
+        context: 'handle-2',
+        url: 'moz-extension://abc123/popup.html',
+        wait: 'none',
+      });
+      // Verify context was set before navigation
+      expect(setCurrentContextId).toHaveBeenCalledWith('handle-2');
+      expect(driver.get).not.toHaveBeenCalled();
+      expect(idx).toBe(1);
+    });
+
+    // With a normal URL, createNewPage delegates to navigate() which uses driver.get()
+    it('uses driver.get() for normal URLs after creating the tab', async () => {
+      const bidiFn = vi.fn().mockResolvedValue({});
+      const allHandles = ['handle-1', 'handle-2'];
+      const driver = {
+        get: vi.fn().mockResolvedValue(undefined),
+        switchTo: vi.fn().mockReturnValue({ newWindow: vi.fn().mockResolvedValue(undefined) }),
+        getAllWindowHandles: vi.fn().mockResolvedValue(allHandles),
+      } as any;
+      const getCurrentContextId = vi.fn().mockReturnValue('handle-2');
+      const setCurrentContextId = vi.fn();
+
+      const pages = new PageManagement(driver, getCurrentContextId, setCurrentContextId, bidiFn as any);
+
+      const idx = await pages.createNewPage('https://example.com');
+
+      expect(driver.get).toHaveBeenCalledWith('https://example.com');
+      expect(bidiFn).not.toHaveBeenCalled();
+      expect(idx).toBe(1);
+    });
+  });
+});

--- a/tests/firefox/pages.test.ts
+++ b/tests/firefox/pages.test.ts
@@ -1,212 +1,174 @@
 /**
- * Unit tests for PageManagement and isPrivilegedUrl
+ * Unit tests for PageManagement and isCommonScheme
  *
- * The moz-extension:// fix: geckodriver's driver.get() hangs on extension URLs
- * because it waits for BiDi navigation completion events that the Remote Agent
- * never emits for extension contexts. The fix routes moz-extension:// URLs
- * through BiDi browsingContext.navigate with wait:"none", which returns
- * immediately without waiting for load events.
+ * Navigation uses BiDi browsingContext.navigate for all URLs.
+ * Common schemes (http/https/data/blob/file) use wait:"interactive".
+ * Uncommon schemes (moz-extension:, about:, etc.) use wait:"none"
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { isPrivilegedUrl, PageManagement } from '@/firefox/pages.js';
+import { isCommonScheme, PageManagement } from '@/firefox/pages.js';
 
-// -- isPrivilegedUrl ----------------------------------------------------------
+const HTTPS_URL = 'https://example.com/test.html';
+const HTTP_URL = 'http://example.com/test.html';
+const FILE_URL = 'file:///some/path/test.html';
+const MOZ_EXT_URL = 'moz-extension://a1b2c3d4-e5f6-7890-abcd-ef1234567890/popup.html';
+const BLOB_URL = 'blob:https://example.org/40a5fb5a-d56d-4a33-b4e2-0acf6a8e5f64';
+const DATA_URL = 'data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==';
 
-describe('isPrivilegedUrl', () => {
-  it('returns true for moz-extension:// URLs', () => {
-    expect(isPrivilegedUrl('moz-extension://abc123/popup.html')).toBe(true);
+describe('isCommonScheme', () => {
+  it('returns true for common URL schemes', () => {
+    expect(isCommonScheme(HTTPS_URL)).toBe(true);
+    expect(isCommonScheme(HTTP_URL)).toBe(true);
+    expect(isCommonScheme(FILE_URL)).toBe(true);
+    expect(isCommonScheme(DATA_URL)).toBe(true);
+    expect(isCommonScheme(BLOB_URL)).toBe(true);
   });
 
-  it('returns false for https:// URLs', () => {
-    expect(isPrivilegedUrl('https://example.com')).toBe(false);
+  it('returns false for moz-extension:// URLs', () => {
+    expect(isCommonScheme(MOZ_EXT_URL)).toBe(false);
   });
 
-  it('returns false for http:// URLs', () => {
-    expect(isPrivilegedUrl('http://localhost:3000')).toBe(false);
+  it('returns false for about: URLs', () => {
+    expect(isCommonScheme('about:blank')).toBe(false);
   });
 
-  it('returns false for file:// URLs', () => {
-    expect(isPrivilegedUrl('file:///path/to/page.html')).toBe(false);
-  });
-
-  it('returns false for about: URLs (not in PRIVILEGED_URL_SCHEMES)', () => {
-    expect(isPrivilegedUrl('about:blank')).toBe(false);
-  });
-
-  // Malformed strings make URL constructor throw; the catch block returns false
   it('returns false for malformed URLs', () => {
-    expect(isPrivilegedUrl('not-a-url')).toBe(false);
-  });
-
-  it('returns false for empty string', () => {
-    expect(isPrivilegedUrl('')).toBe(false);
+    expect(isCommonScheme('not-a-url')).toBe(false);
   });
 });
 
 // -- PageManagement -----------------------------------------------------------
 
 describe('PageManagement', () => {
-  type BiDiCommandFn = (method: string, params: Record<string, any>) => Promise<any>;
-
-  /**
-   * Build mocked PageManagement dependencies.
-   *
-   * The contextId handling is subtle: null and undefined mean different things.
-   * - contextId: null   → explicitly null (no browsing context available)
-   * - contextId omitted → defaults to 'ctx-1' (normal case)
-   *
-   * We use `'contextId' in overrides` to distinguish these, because
-   * `null ?? 'ctx-1'` would incorrectly collapse null into the default.
-   */
-  function createMocks(overrides?: { contextId?: string | null; sendBiDiCommand?: BiDiCommandFn }) {
-    const driver = { get: vi.fn().mockResolvedValue(undefined) } as any;
-    const hasContextId = 'contextId' in (overrides ?? {});
-    const contextId = hasContextId ? overrides!.contextId : 'ctx-1';
-    const getCurrentContextId = vi.fn().mockImplementation(() => contextId);
+  function createMocks() {
+    // Any driver method call should fail — navigate must use BiDi, not driver
+    const driver = new Proxy(
+      {},
+      {
+        get: () => {
+          throw new Error('Unexpected driver call — navigation must use BiDi');
+        },
+      }
+    );
+    const getCurrentContextId = vi.fn().mockReturnValue('ctx-1');
     const setCurrentContextId = vi.fn();
-
-    // When sendBiDiCommand is provided, wrap it in a mock so we can assert calls.
-    // When omitted, it stays undefined — simulates BiDi being unavailable.
-    const sendBiDiCommand = overrides?.sendBiDiCommand
-      ? vi.fn().mockImplementation(overrides.sendBiDiCommand)
-      : undefined;
+    const sendBiDiCommand = vi.fn().mockResolvedValue({});
 
     const pages = new PageManagement(
       driver,
       getCurrentContextId,
       setCurrentContextId,
-      sendBiDiCommand as any
+      sendBiDiCommand
     );
-    return {
-      pages,
-      driver,
-      getCurrentContextId,
-      setCurrentContextId,
-      sendBiDiCommand: sendBiDiCommand as any,
-    };
+    return { pages, sendBiDiCommand };
   }
 
   describe('navigate', () => {
-    // Core fix: moz-extension:// must use BiDi, not driver.get()
-    it('uses BiDi browsingContext.navigate with wait:none for moz-extension:// URLs', async () => {
-      const bidiFn = vi.fn().mockResolvedValue({});
-      const { pages, driver, sendBiDiCommand } = createMocks({ sendBiDiCommand: bidiFn });
+    it('uses BiDi with wait:interactive for common URL schemes', async () => {
+      const { pages, sendBiDiCommand } = createMocks();
 
-      await pages.navigate('moz-extension://abc123/popup.html');
-
+      await pages.navigate(HTTPS_URL);
       expect(sendBiDiCommand).toHaveBeenCalledWith('browsingContext.navigate', {
         context: 'ctx-1',
-        url: 'moz-extension://abc123/popup.html',
+        url: HTTPS_URL,
+        wait: 'interactive',
+      });
+
+      await pages.navigate(HTTP_URL);
+      expect(sendBiDiCommand).toHaveBeenCalledWith('browsingContext.navigate', {
+        context: 'ctx-1',
+        url: HTTP_URL,
+        wait: 'interactive',
+      });
+
+      await pages.navigate(DATA_URL);
+      expect(sendBiDiCommand).toHaveBeenCalledWith('browsingContext.navigate', {
+        context: 'ctx-1',
+        url: DATA_URL,
+        wait: 'interactive',
+      });
+
+      await pages.navigate(FILE_URL);
+      expect(sendBiDiCommand).toHaveBeenCalledWith('browsingContext.navigate', {
+        context: 'ctx-1',
+        url: FILE_URL,
+        wait: 'interactive',
+      });
+
+      await pages.navigate(BLOB_URL);
+      expect(sendBiDiCommand).toHaveBeenCalledWith('browsingContext.navigate', {
+        context: 'ctx-1',
+        url: BLOB_URL,
+        wait: 'interactive',
+      });
+    });
+
+    it('uses BiDi with wait:none for uncommon URL schemes', async () => {
+      const { pages, sendBiDiCommand } = createMocks();
+
+      await pages.navigate(MOZ_EXT_URL);
+      expect(sendBiDiCommand).toHaveBeenCalledWith('browsingContext.navigate', {
+        context: 'ctx-1',
+        url: MOZ_EXT_URL,
         wait: 'none',
       });
-      expect(driver.get).not.toHaveBeenCalled();
-    });
 
-    // Guard: no context ID means we can't send a BiDi command.
-    // Also verify sendBiDiCommand was never called (not just that it threw).
-    it('throws when context ID is null for moz-extension:// URL', async () => {
-      const bidiFn = vi.fn().mockResolvedValue({});
-      const { pages, sendBiDiCommand } = createMocks({ contextId: null, sendBiDiCommand: bidiFn });
+      await pages.navigate('about:blank');
+      expect(sendBiDiCommand).toHaveBeenCalledWith('browsingContext.navigate', {
+        context: 'ctx-1',
+        url: 'about:blank',
+        wait: 'none',
+      });
 
-      await expect(pages.navigate('moz-extension://abc123/popup.html')).rejects.toThrow(
-        'Cannot navigate to privileged URL moz-extension://abc123/popup.html: no browsing context ID'
-      );
-      expect(sendBiDiCommand).not.toHaveBeenCalled();
-    });
-
-    // Fallback: if BiDi is not available (e.g. no Remote Agent), we still try
-    // driver.get(). This will hang for moz-extension://, but there's no alternative.
-    it('falls through to driver.get() for moz-extension:// when BiDi is unavailable', async () => {
-      const { pages, driver, sendBiDiCommand } = createMocks();
-
-      await pages.navigate('moz-extension://abc123/popup.html');
-
-      expect(driver.get).toHaveBeenCalledWith('moz-extension://abc123/popup.html');
-      expect(sendBiDiCommand).toBeUndefined();
-    });
-
-    // Non-privileged URLs always use the standard path
-    it('uses driver.get() for normal URLs', async () => {
-      const bidiFn = vi.fn().mockResolvedValue({});
-      const { pages, driver, sendBiDiCommand } = createMocks({ sendBiDiCommand: bidiFn });
-
-      await pages.navigate('https://example.com');
-
-      expect(driver.get).toHaveBeenCalledWith('https://example.com');
-      expect(sendBiDiCommand).not.toHaveBeenCalled();
-    });
-
-    // If the BiDi command rejects, the error should propagate (no silent swallow)
-    it('propagates BiDi navigation errors for moz-extension:// URLs', async () => {
-      const bidiFn = vi.fn().mockRejectedValue(new Error('BiDi error: invalid context'));
-      const { pages } = createMocks({ sendBiDiCommand: bidiFn });
-
-      await expect(pages.navigate('moz-extension://abc123/popup.html')).rejects.toThrow(
-        'BiDi error: invalid context'
-      );
+      await pages.navigate('not-a-url');
+      expect(sendBiDiCommand).toHaveBeenCalledWith('browsingContext.navigate', {
+        context: 'ctx-1',
+        url: 'not-a-url',
+        wait: 'none',
+      });
     });
   });
 
   describe('createNewPage', () => {
-    // createNewPage must delegate to navigate(), not call driver.get() directly,
-    // so that the moz-extension:// BiDi path is also used for new tabs
-    it('uses BiDi navigate for moz-extension:// URL after creating the tab', async () => {
-      const bidiFn = vi.fn().mockResolvedValue({});
-      const allHandles = ['handle-1', 'handle-2'];
+    it('uses BiDi navigate', async () => {
+      // createNewPage needs real driver methods for switchTo/handles
+      const switchToMock = vi
+        .fn()
+        .mockReturnValue({ newWindow: vi.fn().mockResolvedValue(undefined) });
+      const getAllWindowHandlesMock = vi.fn().mockResolvedValue(['handle-1', 'handle-2']);
+
       const driver = {
-        get: vi.fn().mockResolvedValue(undefined),
-        switchTo: vi.fn().mockReturnValue({ newWindow: vi.fn().mockResolvedValue(undefined) }),
-        getAllWindowHandles: vi.fn().mockResolvedValue(allHandles),
+        switchTo: switchToMock,
+        getAllWindowHandles: getAllWindowHandlesMock,
       } as any;
+
       const getCurrentContextId = vi.fn().mockReturnValue('handle-2');
       const setCurrentContextId = vi.fn();
+      const sendBiDiCommand = vi.fn().mockResolvedValue({});
 
       const pages = new PageManagement(
         driver,
         getCurrentContextId,
         setCurrentContextId,
-        bidiFn as any
+        sendBiDiCommand
       );
 
-      const idx = await pages.createNewPage('moz-extension://abc123/popup.html');
-
-      // Verify the BiDi navigate was used (not driver.get)
-      expect(bidiFn).toHaveBeenCalledWith('browsingContext.navigate', {
+      // wait: interactive
+      await pages.createNewPage(HTTPS_URL);
+      expect(sendBiDiCommand).toHaveBeenCalledWith('browsingContext.navigate', {
         context: 'handle-2',
-        url: 'moz-extension://abc123/popup.html',
+        url: HTTPS_URL,
+        wait: 'interactive',
+      });
+
+      // wait: none
+      await pages.createNewPage(MOZ_EXT_URL);
+      expect(sendBiDiCommand).toHaveBeenCalledWith('browsingContext.navigate', {
+        context: 'handle-2',
+        url: MOZ_EXT_URL,
         wait: 'none',
       });
-      // Verify context was set before navigation
-      expect(setCurrentContextId).toHaveBeenCalledWith('handle-2');
-      expect(driver.get).not.toHaveBeenCalled();
-      expect(idx).toBe(1);
-    });
-
-    // With a normal URL, createNewPage delegates to navigate() which uses driver.get()
-    it('uses driver.get() for normal URLs after creating the tab', async () => {
-      const bidiFn = vi.fn().mockResolvedValue({});
-      const allHandles = ['handle-1', 'handle-2'];
-      const driver = {
-        get: vi.fn().mockResolvedValue(undefined),
-        switchTo: vi.fn().mockReturnValue({ newWindow: vi.fn().mockResolvedValue(undefined) }),
-        getAllWindowHandles: vi.fn().mockResolvedValue(allHandles),
-      } as any;
-      const getCurrentContextId = vi.fn().mockReturnValue('handle-2');
-      const setCurrentContextId = vi.fn();
-
-      const pages = new PageManagement(
-        driver,
-        getCurrentContextId,
-        setCurrentContextId,
-        bidiFn as any
-      );
-
-      const idx = await pages.createNewPage('https://example.com');
-
-      expect(driver.get).toHaveBeenCalledWith('https://example.com');
-      expect(bidiFn).not.toHaveBeenCalled();
-      expect(idx).toBe(1);
     });
   });
 });

--- a/tests/firefox/pages.test.ts
+++ b/tests/firefox/pages.test.ts
@@ -72,8 +72,19 @@ describe('PageManagement', () => {
       ? vi.fn().mockImplementation(overrides.sendBiDiCommand)
       : undefined;
 
-    const pages = new PageManagement(driver, getCurrentContextId, setCurrentContextId, sendBiDiCommand as any);
-    return { pages, driver, getCurrentContextId, setCurrentContextId, sendBiDiCommand: sendBiDiCommand as any };
+    const pages = new PageManagement(
+      driver,
+      getCurrentContextId,
+      setCurrentContextId,
+      sendBiDiCommand as any
+    );
+    return {
+      pages,
+      driver,
+      getCurrentContextId,
+      setCurrentContextId,
+      sendBiDiCommand: sendBiDiCommand as any,
+    };
   }
 
   describe('navigate', () => {
@@ -151,7 +162,12 @@ describe('PageManagement', () => {
       const getCurrentContextId = vi.fn().mockReturnValue('handle-2');
       const setCurrentContextId = vi.fn();
 
-      const pages = new PageManagement(driver, getCurrentContextId, setCurrentContextId, bidiFn as any);
+      const pages = new PageManagement(
+        driver,
+        getCurrentContextId,
+        setCurrentContextId,
+        bidiFn as any
+      );
 
       const idx = await pages.createNewPage('moz-extension://abc123/popup.html');
 
@@ -179,7 +195,12 @@ describe('PageManagement', () => {
       const getCurrentContextId = vi.fn().mockReturnValue('handle-2');
       const setCurrentContextId = vi.fn();
 
-      const pages = new PageManagement(driver, getCurrentContextId, setCurrentContextId, bidiFn as any);
+      const pages = new PageManagement(
+        driver,
+        getCurrentContextId,
+        setCurrentContextId,
+        bidiFn as any
+      );
 
       const idx = await pages.createNewPage('https://example.com');
 

--- a/tests/fixtures/test-extension/manifest.json
+++ b/tests/fixtures/test-extension/manifest.json
@@ -1,0 +1,9 @@
+{
+  "manifest_version": 2,
+  "name": "MCP Test Extension",
+  "version": "1.0",
+  "description": "Minimal extension for testing moz-extension:// navigation",
+  "browser_action": {
+    "default_popup": "popup.html"
+  }
+}

--- a/tests/fixtures/test-extension/popup.html
+++ b/tests/fixtures/test-extension/popup.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>MCP Test Extension</title>
+</head>
+<body>
+  <h1>MCP Test Extension</h1>
+  <p id="status">extension-loaded</p>
+</body>
+</html>

--- a/tests/integration/moz-extension.integration.test.ts
+++ b/tests/integration/moz-extension.integration.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Integration tests for moz-extension:// navigation
+ * Tests with real Firefox browser in headless mode
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createTestFirefox, closeFirefox, waitFor } from '../helpers/firefox.js';
+import type { FirefoxClient } from '@/firefox/index.js';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+import { unlinkSync, existsSync } from 'node:fs';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const fixturesPath = resolve(__dirname, '../fixtures');
+const extensionDir = resolve(fixturesPath, 'test-extension');
+const xpiPath = resolve(fixturesPath, 'test-extension.xpi');
+
+function packExtension(): void {
+  // Remove stale .xpi so zip creates a fresh archive
+  if (existsSync(xpiPath)) {
+    unlinkSync(xpiPath);
+  }
+  // Use execFileSync to avoid shell interpolation of paths
+  execFileSync('zip', ['-j', xpiPath, 'manifest.json', 'popup.html'], {
+    cwd: extensionDir,
+    stdio: 'pipe',
+  });
+}
+
+/**
+ * Get the moz-extension:// hostname for an installed extension by switching
+ * to a chrome-privileged context and querying WebExtensionPolicy.
+ * Requires MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1.
+ */
+async function getExtensionHostname(firefox: FirefoxClient, extensionId: string): Promise<string> {
+  const treeResult = await firefox.sendBiDiCommand('browsingContext.getTree', {
+    'moz:scope': 'chrome',
+  });
+  const contexts = treeResult.contexts || [];
+  if (contexts.length === 0) {
+    throw new Error('No chrome contexts available');
+  }
+
+  const driver = firefox.getDriver();
+  const originalContextId = firefox.getCurrentContextId();
+  const chromeContextId = contexts[0].context;
+
+  try {
+    await driver.switchTo().window(chromeContextId);
+    await driver.setContext('chrome');
+
+    const hostname = await driver.executeAsyncScript(`
+      const callback = arguments[arguments.length - 1];
+      const extensionId = ${JSON.stringify(extensionId)};
+      (async () => {
+        try {
+          const policy = WebExtensionPolicy.getByID(extensionId);
+          callback(policy ? policy.mozExtensionHostname : '');
+        } catch { callback(''); }
+      })();
+    `);
+
+    if (!hostname) {
+      throw new Error(
+        `Could not resolve hostname for extension ${extensionId}, got: ${JSON.stringify(hostname)}`
+      );
+    }
+    return hostname as string;
+  } finally {
+    try {
+      await driver.setContext('content');
+      if (originalContextId) {
+        await driver.switchTo().window(originalContextId);
+      }
+    } catch (e) {
+      console.warn('Failed to restore context after getExtensionHostname:', e);
+    }
+  }
+}
+
+describe('moz-extension:// Navigation Integration Tests', () => {
+  let firefox: FirefoxClient;
+  let extensionUrl: string;
+  let extensionId: string;
+
+  beforeAll(async () => {
+    packExtension();
+
+    // MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1 is required to resolve the extension hostname
+    firefox = await createTestFirefox({
+      env: { MOZ_REMOTE_ALLOW_SYSTEM_ACCESS: '1' },
+    });
+
+    // Install the test extension
+    const installResult = await firefox.sendBiDiCommand('webExtension.install', {
+      extensionData: { type: 'archivePath', path: xpiPath },
+    });
+    extensionId = installResult?.extension;
+    if (!extensionId) {
+      throw new Error(`Extension install returned no ID, got: ${JSON.stringify(installResult)}`);
+    }
+
+    // Resolve the moz-extension:// URL from the extension hostname
+    const hostname = await getExtensionHostname(firefox, extensionId);
+    extensionUrl = `moz-extension://${hostname}/popup.html`;
+  }, 60000);
+
+  afterAll(async () => {
+    // Uninstall the test extension to avoid accumulation across test runs
+    if (extensionId) {
+      try {
+        await firefox.sendBiDiCommand('webExtension.uninstall', { extension: extensionId });
+      } catch {}
+    }
+    await closeFirefox(firefox);
+    // Remove the packed .xpi so no build artifact remains on disk
+    if (existsSync(xpiPath)) {
+      unlinkSync(xpiPath);
+    }
+  });
+
+  it('should navigate to moz-extension:// URL without hanging', async () => {
+    // Before the fix, driver.get() would hang indefinitely because geckodriver
+    // waits for BiDi navigation completion events that the Remote Agent does
+    // not emit for extension contexts.
+    // wait:"none" returns in milliseconds, so a 5s timeout proves no hang
+    // while tolerating slow CI.
+    const result = await Promise.race([
+      firefox.navigate(extensionUrl).then(() => 'navigated'),
+      new Promise<string>((resolve) =>
+        setTimeout(() => resolve('timeout'), 5000)
+      ),
+    ]);
+
+    expect(result).toBe('navigated');
+
+    // Poll for the page URL since wait:none returns before the page loads
+    const driver = firefox.getDriver();
+    await waitFor(async () => {
+      const url = await driver.getCurrentUrl();
+      return url.includes('moz-extension://');
+    }, 5000);
+
+    // Verify the extension page content actually loaded
+    const title = await driver.getTitle();
+    expect(title).toBe('MCP Test Extension');
+  }, 15000);
+
+  it('should create new page with moz-extension:// URL without hanging', async () => {
+    const result = await Promise.race([
+      firefox.createNewPage(extensionUrl).then((idx: number) => `created-${idx}`),
+      new Promise<string>((resolve) =>
+        setTimeout(() => resolve('timeout'), 5000)
+      ),
+    ]);
+
+    expect(result).toMatch(/^created-/);
+
+    // Poll for the page URL since wait:none returns before the page loads
+    const driver = firefox.getDriver();
+    await waitFor(async () => {
+      const url = await driver.getCurrentUrl();
+      return url.includes('moz-extension://');
+    }, 5000);
+
+    // Verify the extension page content actually loaded
+    const title = await driver.getTitle();
+    expect(title).toBe('MCP Test Extension');
+  }, 15000);
+});

--- a/tests/integration/moz-extension.integration.test.ts
+++ b/tests/integration/moz-extension.integration.test.ts
@@ -1,9 +1,15 @@
 /**
- * Integration tests for moz-extension:// navigation
- * Tests with real Firefox browser in headless mode
+ * Integration tests for BiDi navigation
+ * Tests with real Firefox browser in headless mode.
+ *
+ * Navigation uses BiDi browsingContext.navigate for all URLs.
+ * Standard schemes (http/https/data/blob/file) use wait:"interactive".
+ * Non-standard schemes (moz-extension:, about:) use wait:"none" because
+ * the Remote Agent doesn't emit navigation completion events for
+ * extension/privileged contexts.
  */
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
 import { createTestFirefox, closeFirefox, waitFor } from '../helpers/firefox.js';
 import type { FirefoxClient } from '@/firefox/index.js';
 import { resolve } from 'node:path';
@@ -79,7 +85,26 @@ async function getExtensionHostname(firefox: FirefoxClient, extensionId: string)
   }
 }
 
-describe('moz-extension:// Navigation Integration Tests', () => {
+/**
+ * Race a promise against a timeout. Resolves 'ok' on success, 'timeout' if
+ * the timeout fires, or rejects with the original error.
+ */
+function raceWithTimeout(promise: Promise<any>, ms: number): Promise<'ok' | 'timeout'> {
+  let timer: ReturnType<typeof setTimeout>;
+  return Promise.race([
+    promise.then(
+      () => 'ok' as const,
+      (e: any) => {
+        throw e;
+      }
+    ),
+    new Promise<'timeout'>((resolve) => {
+      timer = setTimeout(() => resolve('timeout'), ms);
+    }),
+  ]).finally(() => clearTimeout(timer));
+}
+
+describe('BiDi Navigation Integration Tests', () => {
   let firefox: FirefoxClient;
   let extensionUrl: string;
   let extensionId: string;
@@ -120,18 +145,22 @@ describe('moz-extension:// Navigation Integration Tests', () => {
     }
   });
 
-  it('should navigate to moz-extension:// URL without hanging', async () => {
-    // Before the fix, driver.get() would hang indefinitely because geckodriver
-    // waits for BiDi navigation completion events that the Remote Agent does
-    // not emit for extension contexts.
-    // wait:"none" returns in milliseconds, so a 5s timeout proves no hang
-    // while tolerating slow CI.
-    const result = await Promise.race([
-      firefox.navigate(extensionUrl).then(() => 'navigated'),
-      new Promise<string>((resolve) => setTimeout(() => resolve('timeout'), 5000)),
-    ]);
+  // Reset to a clean state between tests
+  afterEach(async () => {
+    try {
+      await firefox.navigate('about:blank');
+    } catch {
+      // Best-effort reset
+    }
+  });
 
-    expect(result).toBe('navigated');
+  it('should navigate to moz-extension:// URL without hanging', async () => {
+    // Non-standard schemes use wait:"none" because the Remote Agent
+    // doesn't emit navigation completion events for extension contexts.
+    // A 5s timeout proves no hang while tolerating slow CI.
+    const result = await raceWithTimeout(firefox.navigate(extensionUrl), 5000);
+
+    expect(result).toBe('ok');
 
     // Poll for the page URL since wait:none returns before the page loads
     const driver = firefox.getDriver();
@@ -140,18 +169,17 @@ describe('moz-extension:// Navigation Integration Tests', () => {
       return url.includes('moz-extension://');
     }, 5000);
 
-    // Verify the extension page content actually loaded
     const title = await driver.getTitle();
     expect(title).toBe('MCP Test Extension');
   }, 15000);
 
   it('should create new page with moz-extension:// URL without hanging', async () => {
-    const result = await Promise.race([
-      firefox.createNewPage(extensionUrl).then((idx: number) => `created-${idx}`),
-      new Promise<string>((resolve) => setTimeout(() => resolve('timeout'), 5000)),
-    ]);
+    const result = await raceWithTimeout(
+      firefox.createNewPage(extensionUrl).then((idx: number) => idx),
+      5000
+    );
 
-    expect(result).toMatch(/^created-/);
+    expect(result).toBe('ok');
 
     // Poll for the page URL since wait:none returns before the page loads
     const driver = firefox.getDriver();
@@ -160,8 +188,21 @@ describe('moz-extension:// Navigation Integration Tests', () => {
       return url.includes('moz-extension://');
     }, 5000);
 
-    // Verify the extension page content actually loaded
     const title = await driver.getTitle();
     expect(title).toBe('MCP Test Extension');
+
+    // Clean up the created tab
+    try {
+      const handles = await driver.getAllWindowHandles();
+      if (handles.length > 1) {
+        await driver.close();
+        const remaining = await driver.getAllWindowHandles();
+        if (remaining.length > 0) {
+          await driver.switchTo().window(remaining[0]!);
+        }
+      }
+    } catch {
+      // Best-effort cleanup
+    }
   }, 15000);
 });

--- a/tests/integration/moz-extension.integration.test.ts
+++ b/tests/integration/moz-extension.integration.test.ts
@@ -128,9 +128,7 @@ describe('moz-extension:// Navigation Integration Tests', () => {
     // while tolerating slow CI.
     const result = await Promise.race([
       firefox.navigate(extensionUrl).then(() => 'navigated'),
-      new Promise<string>((resolve) =>
-        setTimeout(() => resolve('timeout'), 5000)
-      ),
+      new Promise<string>((resolve) => setTimeout(() => resolve('timeout'), 5000)),
     ]);
 
     expect(result).toBe('navigated');
@@ -150,9 +148,7 @@ describe('moz-extension:// Navigation Integration Tests', () => {
   it('should create new page with moz-extension:// URL without hanging', async () => {
     const result = await Promise.race([
       firefox.createNewPage(extensionUrl).then((idx: number) => `created-${idx}`),
-      new Promise<string>((resolve) =>
-        setTimeout(() => resolve('timeout'), 5000)
-      ),
+      new Promise<string>((resolve) => setTimeout(() => resolve('timeout'), 5000)),
     ]);
 
     expect(result).toMatch(/^created-/);

--- a/tests/integration/moz-extension.integration.test.ts
+++ b/tests/integration/moz-extension.integration.test.ts
@@ -85,25 +85,6 @@ async function getExtensionHostname(firefox: FirefoxClient, extensionId: string)
   }
 }
 
-/**
- * Race a promise against a timeout. Resolves 'ok' on success, 'timeout' if
- * the timeout fires, or rejects with the original error.
- */
-function raceWithTimeout(promise: Promise<any>, ms: number): Promise<'ok' | 'timeout'> {
-  let timer: ReturnType<typeof setTimeout>;
-  return Promise.race([
-    promise.then(
-      () => 'ok' as const,
-      (e: any) => {
-        throw e;
-      }
-    ),
-    new Promise<'timeout'>((resolve) => {
-      timer = setTimeout(() => resolve('timeout'), ms);
-    }),
-  ]).finally(() => clearTimeout(timer));
-}
-
 describe('BiDi Navigation Integration Tests', () => {
   let firefox: FirefoxClient;
   let extensionUrl: string;
@@ -157,10 +138,7 @@ describe('BiDi Navigation Integration Tests', () => {
   it('should navigate to moz-extension:// URL without hanging', async () => {
     // Non-standard schemes use wait:"none" because the Remote Agent
     // doesn't emit navigation completion events for extension contexts.
-    // A 5s timeout proves no hang while tolerating slow CI.
-    const result = await raceWithTimeout(firefox.navigate(extensionUrl), 5000);
-
-    expect(result).toBe('ok');
+    await firefox.navigate(extensionUrl);
 
     // Poll for the page URL since wait:none returns before the page loads
     const driver = firefox.getDriver();
@@ -174,12 +152,7 @@ describe('BiDi Navigation Integration Tests', () => {
   }, 15000);
 
   it('should create new page with moz-extension:// URL without hanging', async () => {
-    const result = await raceWithTimeout(
-      firefox.createNewPage(extensionUrl).then((idx: number) => idx),
-      5000
-    );
-
-    expect(result).toBe('ok');
+    await firefox.createNewPage(extensionUrl);
 
     // Poll for the page URL since wait:none returns before the page loads
     const driver = firefox.getDriver();


### PR DESCRIPTION
## The problem

**TLDR:** Navigating to `moz-extension://` URLs doesn't work. `driver.get()` hangs because the underlying BiDi command never gets a response.

When navigating to a `moz-extension://` URL, the `PageManagement.navigate()` method uses Selenium to send a HTTP request to Geckodriver that sends a WebDriver BiDi request to Firefox (the BiDi Remote Agent server) to load the extension page. The Remote Agent recives the message and Firefox changes the page. The problem is that Firefox never triggers the **"i am done"** event when loading extension pages, thus never triggers the Remote Agent to send a response back to Geckodriver, leaving Geckodriver listening for a response indefinitely. There is no timeout.

This is the same class of bug as the [zombie-geckodriver](https://github.com/mozilla/firefox-devtools-mcp/pull/86) fix: geckodriver blocks indefinitely when Firefox doesn't respond. In the zombie case, Firefox is gone entirely. Here, Firefox is alive but the Remote Agent never responds.

So there are actually two upstream bugs, one in Geckodriver and one in the Remote Agent.
This fix is just a workaround that makes the MCP work anyway. When the actual bugs are fixed, this becomes unecessary.

## The solution

**TLDR:** Bypass Geckodriver entirely and send a manual BiDi request over WebSocket to Firefox.

Instead of using `driver.get()` to query Firefox, which uses Geckodriver, we instead send a manual WebDriver BiDi command `browsingContext.navigate` with `wait: "none"` using `FirefoxCore.sendBiDiCommand`, causing the Remote Agent to load the page and respond immediately. 

The downside is that there is no timing guarantee. The extension might not actually have finished loading when the MCP tool call returns. But in an AI agent context, it likely doesn't matter in practice

## Files changed

- Edit `src/firefox/index.ts` - Pass `sendBiDiCommand` callback to `PageManagement`
- Edit `src/firefox/pages.ts` - Add `isPrivilegedUrl()`. Add BiDi navigation to `navigate()`. Use `navigate()` in `createNewPage()`

## Tests

- `tests/firefox/pages.test.ts` - Unit tests for isPrivilegedUrl, navigate and the createNewPage delegation
- `tests/integration/moz-extension.integration.test.ts` - Integration tests with real Firefox: installs a fixture extension, resolves its UUID to construct valid moz-extension:// URLs, and verifies navigation without hanging
- `tests/fixtures/test-extension/` - Minimal extension fixture for integration tests