### PR TITLE
Bug 2032055 - feature: add support for connecting to Firefox for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,30 @@ You can pass flags or environment variables (names on the right):
 - `--pref name=value` — set Firefox preference at startup via `moz:firefoxOptions` (repeatable)
 - `--enable-script` — enable the `evaluate_script` tool, which executes arbitrary JavaScript in the page context (`ENABLE_SCRIPT=true`)
 - `--enable-privileged-context` — enable privileged context tools: list/select privileged contexts, evaluate privileged scripts, get/set Firefox prefs, and list extensions. Requires `MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1` (`ENABLE_PRIVILEGED_CONTEXT=true`)
+- `--android-device` — enable Firefox for Android mode; value is the ADB device serial (e.g. `emulator-5554`). Run `adb devices` to list connected devices. Omit the value or use `auto` to select the single connected device automatically.
+- `--android-package` — Android app package name, default `org.mozilla.firefox`. Other packages: `org.mozilla.firefox_beta` for Firefox Beta, `org.mozilla.fenix` for Firefox Nightly, `org.mozilla.fenix.debug` for Firefox Nightly Debug, `org.mozilla.geckoview_example` for geckoview (`ANDROID_PACKAGE`)
 
 > **Note on `--pref`:** When Firefox runs in automation, it applies [RecommendedPreferences](https://searchfox.org/firefox-main/source/remote/shared/RecommendedPreferences.sys.mjs) that modify browser behavior for testing. The `--pref` option allows overriding these defaults when needed.
+
+### Firefox for Android
+
+Use `--android-device` to automate Firefox running on an Android device. Requires `adb` on your PATH and geckodriver, which is managed automatically.
+
+```bash
+# List connected devices
+adb devices
+
+# Launch Firefox for Android on the single connected device
+npx firefox-devtools-mcp --android-device auto
+
+# Target a specific device
+npx firefox-devtools-mcp --android-device <serial>
+
+# Use Firefox Nightly instead
+npx firefox-devtools-mcp --android-device <serial> --android-package org.mozilla.fenix
+```
+
+Port forwarding between the host and device is handled automatically by geckodriver.
 
 ### Connect to existing Firefox
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -127,6 +127,17 @@ export const cliOptions = {
       'Set Firefox preference at startup via moz:firefoxOptions (format: name=value). Can be specified multiple times.',
     alias: 'p',
   },
+  androidDevice: {
+    type: 'string',
+    description:
+      'Android device serial for launching Firefox for Android via ADB. Omit to auto-select the single connected device. Requires adb on PATH.',
+  },
+  androidPackage: {
+    type: 'string',
+    description:
+      'Android app package name (default: org.mozilla.firefox). Use org.mozilla.fenix for Nightly.',
+    default: process.env.ANDROID_PACKAGE ?? 'org.mozilla.firefox',
+  },
   enableScript: {
     type: 'boolean',
     description:

--- a/src/firefox/core.ts
+++ b/src/firefox/core.ts
@@ -80,13 +80,43 @@ export class FirefoxCore {
    * Launch Firefox (or connect to an existing instance) and establish BiDi connection
    */
   async connect(): Promise<void> {
-    if (this.options.connectExisting) {
+    const isAndroid = this.options.androidDevice !== undefined;
+
+    if (isAndroid) {
+      log('Launching Firefox for Android via ADB...');
+    } else if (this.options.connectExisting) {
       log('Connecting to existing Firefox via Marionette...');
     } else {
       log('Launching Firefox via Selenium WebDriver BiDi...');
     }
 
-    if (this.options.connectExisting) {
+    if (isAndroid) {
+      // Pre-set the geckodriver path so selenium-webdriver skips getBinaryPaths(),
+      // which would otherwise discover the desktop Firefox binary and inject it into
+      // moz:firefoxOptions.binary — conflicting with androidPackage.
+      const geckodriverPath = await findGeckodriver();
+      logDebug(`Using geckodriver: ${geckodriverPath}`);
+
+      const pkg = this.options.androidPackage ?? 'org.mozilla.firefox';
+      const mozOptions: Record<string, unknown> = { androidPackage: pkg };
+      const deviceSerial = this.options.androidDevice;
+      if (deviceSerial && deviceSerial !== 'auto') {
+        mozOptions.androidDeviceSerial = deviceSerial;
+      }
+      if (this.options.prefs) {
+        mozOptions.prefs = this.options.prefs;
+      }
+
+      const caps = new Capabilities();
+      caps.set('webSocketUrl', true);
+      caps.set('moz:firefoxOptions', mozOptions);
+      if (this.options.acceptInsecureCerts) {
+        caps.set('acceptInsecureCerts', true);
+      }
+
+      const serviceBuilder = new firefox.ServiceBuilder(geckodriverPath);
+      this.driver = firefox.Driver.createSession(caps, serviceBuilder.build());
+    } else if (this.options.connectExisting) {
       const port = this.options.marionettePort ?? 2828;
 
       // Find geckodriver binary (--driver avoids downloading Firefox via selenium-manager)

--- a/src/firefox/types.ts
+++ b/src/firefox/types.ts
@@ -64,6 +64,10 @@ export interface FirefoxLaunchOptions {
   logFile?: string | undefined;
   /** Firefox preferences to set at startup via moz:firefoxOptions */
   prefs?: Record<string, string | number | boolean> | undefined;
+  /** Android device serial; omit to auto-select the single connected device */
+  androidDevice?: string | undefined;
+  /** Android app package name (default: org.mozilla.firefox) */
+  androidPackage?: string | undefined;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,6 +127,8 @@ export async function getFirefox(): Promise<FirefoxDevTools> {
       env: envVars,
       logFile: args.outputFile ?? undefined,
       prefs,
+      androidDevice: args.androidDevice ?? undefined,
+      androidPackage: args.androidPackage ?? undefined,
     };
   }
 


### PR DESCRIPTION
This PR adds support for connecting to Firefox for Android via 2 new command line arguments: `--android-device` and `--android-package`. 