### PR TITLE
Bug 2046777 - fix: use about:blank as start url instead of about:home

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Add to your Claude Code config file:
       "command": "npx",
       "args": ["-y", "@mozilla/firefox-devtools-mcp@latest", "--headless", "--viewport", "1280x720"],
       "env": {
-        "START_URL": "about:home"
+        "START_URL": "about:blank"
       }
     }
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -96,8 +96,8 @@ export const cliOptions = {
   },
   startUrl: {
     type: 'string',
-    description: 'URL to open when Firefox starts (default: about:home)',
-    default: process.env.START_URL ?? 'about:home',
+    description: 'URL to open when Firefox starts (default: about:blank)',
+    default: process.env.START_URL ?? 'about:blank',
   },
   connectExisting: {
     type: 'boolean',

--- a/src/tools/firefox-management.ts
+++ b/src/tools/firefox-management.ts
@@ -220,7 +220,7 @@ export const restartFirefoxTool = {
       startUrl: {
         type: 'string',
         description:
-          'URL to navigate to after restart (optional, uses about:home if not specified)',
+          'URL to navigate to after restart (optional, uses about:blank if not specified)',
       },
       prefs: {
         type: 'object',
@@ -282,7 +282,7 @@ export async function handleRestartFirefox(input: unknown) {
         profilePath: profilePath ?? currentOptions.profilePath,
         env: newEnv !== undefined ? newEnv : currentOptions.env,
         headless: headless !== undefined ? headless : currentOptions.headless,
-        startUrl: startUrl ?? currentOptions.startUrl ?? 'about:home',
+        startUrl: startUrl ?? currentOptions.startUrl ?? 'about:blank',
         prefs: mergedPrefs,
       };
 
@@ -350,7 +350,7 @@ export async function handleRestartFirefox(input: unknown) {
         profilePath: profilePath ?? args.profilePath ?? undefined,
         env: newEnv,
         headless: headless ?? false,
-        startUrl: startUrl ?? 'about:home',
+        startUrl: startUrl ?? 'about:blank',
       };
 
       setNextLaunchOptions(newOptions);


### PR DESCRIPTION
about:home is restricted and can lead to issues with recent builds of Firefox Nightly.