### PR TITLE
Bug 2047657 - feature: add support for debugging logpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ You can pass flags or environment variables (names on the right):
 - `--connect-existing` — attach to an already-running Firefox instead of launching a new one (`CONNECT_EXISTING=true`)
 - `--marionette-port` — Marionette port for connect-existing mode, default 2828 (`MARIONETTE_PORT`)
 - `--pref name=value` — set Firefox preference at startup via `moz:firefoxOptions` (repeatable)
-- `--enable-script` — enable the `evaluate_script` tool, which executes arbitrary JavaScript in the page context (`ENABLE_SCRIPT=true`)
+- `--enable-script` — enable the `evaluate_script` tool (executes arbitrary JavaScript in the page context) and debugging tools (list scripts, inspect source, set logpoints). Debugging tools require Firefox 153+. (`ENABLE_SCRIPT=true`)
 - `--enable-privileged-context` — enable privileged context tools: list/select privileged contexts, evaluate privileged scripts, get/set Firefox prefs, and list extensions. Requires `MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1` (`ENABLE_PRIVILEGED_CONTEXT=true`)
 - `--android-device` — enable Firefox for Android mode; value is the ADB device serial (e.g. `emulator-5554`). Run `adb devices` to list connected devices. Omit the value or use `auto` to select the single connected device automatically.
 - `--android-package` — Android app package name, default `org.mozilla.firefox`. Other packages: `org.mozilla.firefox_beta` for Firefox Beta, `org.mozilla.fenix` for Firefox Nightly, `org.mozilla.fenix.debug` for Firefox Nightly Debug, `org.mozilla.geckoview_example` for geckoview (`ANDROID_PACKAGE`)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -146,7 +146,7 @@ export const cliOptions = {
   enableScript: {
     type: 'boolean',
     description:
-      'Enable the evaluate_script tool, which allows executing arbitrary JavaScript in the page context.',
+      'Enable the script tools such as script evaluation and logpoints (Firefox 153+ required).',
     default: (process.env.ENABLE_SCRIPT ?? 'false') === 'true',
   },
   enablePrivilegedContext: {

--- a/src/firefox/events/debugging.ts
+++ b/src/firefox/events/debugging.ts
@@ -1,0 +1,141 @@
+/**
+ * moz:debugging event handling
+ */
+
+import type { WebDriver } from 'selenium-webdriver';
+import type { LogpointResult } from '../types.js';
+import { logDebug } from '../../utils/logger.js';
+
+interface LogpointEntry {
+  expression: string;
+  location: { url: string; line: number };
+  results: LogpointResult[];
+}
+
+export class DebuggingEvents {
+  private logpoints: Map<string, LogpointEntry> = new Map();
+  private subscribed = false;
+
+  constructor(
+    private driver: WebDriver,
+    private sendBiDiCommand: (method: string, params: Record<string, any>) => Promise<any>
+  ) {}
+
+  /**
+   * Subscribe to moz:debugging events
+   */
+  async subscribe(contextId?: string): Promise<void> {
+    if (this.subscribed) {
+      return;
+    }
+
+    const bidi = await this.driver.getBidi();
+    try {
+      await bidi.subscribe('moz:debugging.paused', contextId ? [contextId] : undefined);
+      await bidi.subscribe('moz:debugging.resumed', contextId ? [contextId] : undefined);
+    } catch {
+      logDebug(
+        'Debugging events subscription skipped (may not be available in this Firefox version)'
+      );
+    }
+
+    const ws: any = bidi.socket;
+    ws.on('message', (data: any) => {
+      try {
+        const payload = JSON.parse(data.toString());
+
+        if (payload?.method === 'moz:debugging.paused') {
+          const { context, url, line, column } = payload.params;
+          const logpointId = this.findLogpointByLocation(url, line);
+          if (logpointId) {
+            void this.handleLogpointPause(context, logpointId);
+            return;
+          }
+          logDebug(`moz:Debugging paused in context: ${context} at ${url}:${line}:${column}`);
+        }
+
+        if (payload?.method === 'moz:debugging.resumed') {
+          logDebug(`moz:Debugging resumed in context: ${payload.params.context}`);
+        }
+      } catch {
+        // Ignore event processing failures
+      }
+    });
+
+    this.subscribed = true;
+    logDebug('moz:debugging listener active');
+  }
+
+  addLogpoint(logpointId: string, url: string, line: number, expression: string): void {
+    this.logpoints.set(logpointId, {
+      location: { url, line },
+      expression,
+      results: [],
+    });
+  }
+
+  removeLogpoint(logpointId: string): void {
+    this.logpoints.delete(logpointId);
+  }
+
+  getLogpointResults(logpointId: string): LogpointResult[] | null {
+    return this.logpoints.get(logpointId)?.results ?? null;
+  }
+
+  private findLogpointByLocation(url: string, line: number): string | null {
+    for (const [logpointId, entry] of this.logpoints) {
+      if (entry.location.url === url && entry.location.line === line) {
+        return logpointId;
+      }
+    }
+    return null;
+  }
+
+  private async handleLogpointPause(contextId: string, logpointId: string): Promise<void> {
+    const entry = this.logpoints.get(logpointId);
+    if (!entry) {
+      return;
+    }
+
+    logDebug(`Logpoint hit: ${logpointId} in context ${contextId}`);
+
+    try {
+      // Bug 2047506: script.callFunction fails when paused, use script.evaluate
+      // for now.
+      const result = await this.sendBiDiCommand('script.evaluate', {
+        expression: entry.expression,
+        target: { context: contextId },
+        awaitPromise: false,
+      });
+
+      const evalResult = result as {
+        type: string;
+        result?: unknown;
+        exceptionDetails?: { text: string };
+      };
+
+      if (evalResult.type === 'exception') {
+        entry.results.push({
+          value: null,
+          error: evalResult.exceptionDetails?.text ?? 'Unknown error',
+          timestamp: Date.now(),
+        });
+      } else {
+        entry.results.push({
+          value: evalResult.result,
+          timestamp: Date.now(),
+        });
+      }
+    } catch (error) {
+      entry.results.push({
+        value: null,
+        error: String(error),
+        timestamp: Date.now(),
+      });
+    } finally {
+      await this.sendBiDiCommand('moz:debugging.resume', { context: contextId }).catch((err) => {
+        logDebug(`Failed to resume after logpoint: ${String(err)}`);
+      });
+    }
+  }
+}

--- a/src/firefox/events/debugging.ts
+++ b/src/firefox/events/debugging.ts
@@ -6,10 +6,13 @@ import type { WebDriver } from 'selenium-webdriver';
 import type { LogpointResult } from '../types.js';
 import { logDebug } from '../../utils/logger.js';
 
+const MAX_LOGPOINT_RESULTS = 100;
+
 interface LogpointEntry {
   expression: string;
   location: { url: string; line: number };
   results: LogpointResult[];
+  capped: boolean;
 }
 
 export class DebuggingEvents {
@@ -71,6 +74,7 @@ export class DebuggingEvents {
       location: { url, line },
       expression,
       results: [],
+      capped: false,
     });
   }
 
@@ -133,6 +137,13 @@ export class DebuggingEvents {
         timestamp: Date.now(),
       });
     } finally {
+      if (entry.results.length > MAX_LOGPOINT_RESULTS) {
+        entry.results.splice(0, entry.results.length - MAX_LOGPOINT_RESULTS);
+        if (!entry.capped) {
+          entry.capped = true;
+          logDebug(`Logpoint ${logpointId}: result buffer capped at ${MAX_LOGPOINT_RESULTS}`);
+        }
+      }
       await this.sendBiDiCommand('moz:debugging.resume', { context: contextId }).catch((err) => {
         logDebug(`Failed to resume after logpoint: ${String(err)}`);
       });

--- a/src/firefox/events/index.ts
+++ b/src/firefox/events/index.ts
@@ -4,3 +4,4 @@
 
 export { ConsoleEvents, type ConsoleEventsOptions } from './console.js';
 export { NetworkEvents, type NetworkEventsOptions } from './network.js';
+export { DebuggingEvents } from './debugging.js';

--- a/src/firefox/index.ts
+++ b/src/firefox/index.ts
@@ -2,11 +2,11 @@
  * Firefox Client - Public facade for modular Firefox automation
  */
 
-import type { FirefoxLaunchOptions, ConsoleMessage } from './types.js';
+import type { FirefoxLaunchOptions, ConsoleMessage, LogpointResult } from './types.js';
 import { WebElement } from 'selenium-webdriver';
 import { FirefoxCore } from './core.js';
 import { logDebug } from '../utils/logger.js';
-import { ConsoleEvents, NetworkEvents } from './events/index.js';
+import { ConsoleEvents, NetworkEvents, DebuggingEvents } from './events/index.js';
 import { DomInteractions } from './dom.js';
 import { PageManagement } from './pages.js';
 import { SnapshotManager, type Snapshot, type SnapshotOptions } from './snapshot/index.js';
@@ -19,6 +19,7 @@ export class FirefoxClient {
   private core: FirefoxCore;
   private consoleEvents: ConsoleEvents | null = null;
   private networkEvents: NetworkEvents | null = null;
+  private debuggingEvents: DebuggingEvents | null = null;
   private dom: DomInteractions | null = null;
   private pages: PageManagement | null = null;
   private snapshot: SnapshotManager | null = null;
@@ -64,6 +65,10 @@ export class FirefoxClient {
         onNavigate,
         autoClearOnNavigate: false,
       });
+
+      this.debuggingEvents = new DebuggingEvents(driver as any, (method, params) =>
+        this.core.sendBiDiCommand(method, params)
+      );
     }
 
     // Initialize DOM with UID resolver callback
@@ -97,6 +102,14 @@ export class FirefoxClient {
       } catch {
         logDebug('Network events unavailable (BiDi not supported by this Firefox session)');
         this.networkEvents = null;
+      }
+    }
+    if (this.debuggingEvents) {
+      try {
+        await this.debuggingEvents.subscribe();
+      } catch {
+        logDebug('Debugging events unavailable (BiDi not supported by this Firefox session)');
+        this.debuggingEvents = null;
       }
     }
   }
@@ -453,6 +466,44 @@ export class FirefoxClient {
   }
 
   /**
+   * @internal
+   */
+  async setLogpoint(url: string, line: number, expression: string): Promise<string> {
+    if (!this.debuggingEvents) {
+      throw new Error('Debugging events not available');
+    }
+    const result = await this.core.sendBiDiCommand('moz:debugging.setBreakpoint', {
+      location: { url, line },
+    });
+    const logpointId = (result as { breakpoint: string }).breakpoint;
+    this.debuggingEvents.addLogpoint(logpointId, url, line, expression);
+    return logpointId;
+  }
+
+  /**
+   * @internal
+   */
+  async removeLogpoint(logpointId: string): Promise<void> {
+    if (!this.debuggingEvents) {
+      throw new Error('Debugging events not available');
+    }
+    await this.core.sendBiDiCommand('moz:debugging.removeBreakpoint', {
+      breakpoint: logpointId,
+    });
+    this.debuggingEvents.removeLogpoint(logpointId);
+  }
+
+  /**
+   * @internal
+   */
+  getLogpointResults(logpointId: string): LogpointResult[] | null {
+    if (!this.debuggingEvents) {
+      return null;
+    }
+    return this.debuggingEvents.getLogpointResults(logpointId);
+  }
+
+  /**
    * Get log file path (if logging is enabled)
    */
   getLogFilePath(): string | undefined {
@@ -486,6 +537,7 @@ export class FirefoxClient {
     }
     this.consoleEvents = null;
     this.networkEvents = null;
+    this.debuggingEvents = null;
     this.dom = null;
     this.pages = null;
     this.snapshot = null;

--- a/src/firefox/types.ts
+++ b/src/firefox/types.ts
@@ -48,6 +48,15 @@ export interface NetworkRecord {
 }
 
 /**
+ * A single result captured by a logpoint hit
+ */
+export interface LogpointResult {
+  value: unknown;
+  error?: string;
+  timestamp: number;
+}
+
+/**
  * Firefox launch options
  */
 export interface FirefoxLaunchOptions {

--- a/src/index.ts
+++ b/src/index.ts
@@ -231,6 +231,18 @@ export async function run(
     // Script evaluation — requires --enable-script
     ...(args.enableScript ? ([['evaluate_script', tools.handleEvaluateScript]] as const) : []),
 
+    // Debugging tools — requires --enable-script
+    ...(args.enableScript
+      ? ([
+          ['enable_debugger', tools.handleEnableDebugger],
+          ['list_scripts', tools.handleListScripts],
+          ['get_script_source', tools.handleGetScriptSource],
+          ['set_logpoint', tools.handleSetLogpoint],
+          ['remove_logpoint', tools.handleRemoveLogpoint],
+          ['get_logpoint_results', tools.handleGetLogpointResults],
+        ] as const)
+      : []),
+
     // Privileged context tools — requires --enable-privileged-context
     ...(args.enablePrivilegedContext
       ? ([
@@ -295,6 +307,18 @@ export async function run(
 
     // Script evaluation — requires --enable-script
     ...(args.enableScript ? [tools.evaluateScriptTool] : []),
+
+    // Debugging tools — requires --enable-script
+    ...(args.enableScript
+      ? [
+          tools.enableDebuggerTool,
+          tools.listScriptsTool,
+          tools.getScriptSourceTool,
+          tools.setLogpointTool,
+          tools.removeLogpointTool,
+          tools.getLogpointResultsTool,
+        ]
+      : []),
 
     // Privileged context tools — requires --enable-privileged-context
     ...(args.enablePrivilegedContext

--- a/src/tools/debugging.ts
+++ b/src/tools/debugging.ts
@@ -1,0 +1,198 @@
+import { successResponse, errorResponse } from '../utils/response-helpers.js';
+import { compareVersions } from '../utils/version.js';
+import { remoteValueToNative } from '../utils/remote-value.js';
+import type { McpToolResponse } from '../types/common.js';
+
+const MIN_VERSION = '153';
+
+function requireDebuggingSupport(firefox: { getFirefoxVersion(): string | null }): void {
+  const version = firefox.getFirefoxVersion();
+  if (version !== null && compareVersions(version, MIN_VERSION) < 0) {
+    throw new Error(
+      `moz:debugging requires Firefox ${MIN_VERSION}+, current version is ${version}`
+    );
+  }
+}
+
+function requireContext(contextId: string | null): string {
+  if (!contextId) {
+    throw new Error('No active browsing context');
+  }
+  return contextId;
+}
+
+// ============================================================================
+// Tool definitions
+// ============================================================================
+
+export const enableDebuggerTool = {
+  name: 'enable_debugger',
+  description:
+    'Enable the JS debugger for the current page. Required before set_logpoint works. Requires Firefox 153+.',
+  inputSchema: { type: 'object', properties: {} },
+};
+
+export const listScriptsTool = {
+  name: 'list_scripts',
+  description:
+    'List all JavaScript files currently loaded in the page. Requires enable_debugger to have been called.',
+  inputSchema: { type: 'object', properties: {} },
+};
+
+export const getScriptSourceTool = {
+  name: 'get_script_source',
+  description:
+    'Get the source code of a JavaScript file loaded in the page. Requires enable_debugger to have been called.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      scriptUrl: { type: 'string', description: 'URL of the script to retrieve.' },
+    },
+    required: ['scriptUrl'],
+  },
+};
+
+export const setLogpointTool = {
+  name: 'set_logpoint',
+  description:
+    'Set a logpoint at a specific location. When execution reaches that line, the expression is evaluated and the result is stored without pausing. Use get_logpoint_results to retrieve collected values. Requires enable_debugger to have been called.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      url: { type: 'string', description: 'URL of the script.' },
+      line: { type: 'number', description: 'Line number (1-based).' },
+      expression: {
+        type: 'string',
+        description: 'JavaScript expression to evaluate each time the logpoint is hit.',
+      },
+    },
+    required: ['url', 'line', 'expression'],
+  },
+};
+
+export const removeLogpointTool = {
+  name: 'remove_logpoint',
+  description: 'Remove a previously set logpoint.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      logpoint: { type: 'string', description: 'Logpoint id returned by set_logpoint.' },
+    },
+    required: ['logpoint'],
+  },
+};
+
+export const getLogpointResultsTool = {
+  name: 'get_logpoint_results',
+  description: 'Get the results collected by a logpoint since it was set.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      logpoint: { type: 'string', description: 'Logpoint id returned by set_logpoint.' },
+    },
+    required: ['logpoint'],
+  },
+};
+
+// ============================================================================
+// Handlers
+// ============================================================================
+
+export async function handleEnableDebugger(_args: unknown): Promise<McpToolResponse> {
+  try {
+    const { getFirefox } = await import('../index.js');
+    const firefox = await getFirefox();
+    requireDebuggingSupport(firefox);
+    await firefox.sendBiDiCommand('moz:debugging.setDebuggerEnabled', { enabled: true });
+    return successResponse('Debugger enabled');
+  } catch (error) {
+    return errorResponse(error as Error);
+  }
+}
+
+export async function handleListScripts(_args: unknown): Promise<McpToolResponse> {
+  try {
+    const { getFirefox } = await import('../index.js');
+    const firefox = await getFirefox();
+    requireDebuggingSupport(firefox);
+    const contextId = requireContext(firefox.getCurrentContextId());
+    const result = await firefox.sendBiDiCommand('moz:debugging.listScripts', {
+      context: contextId,
+    });
+    const scripts = (result as { scripts: string[] }).scripts;
+    if (scripts.length === 0) {
+      return successResponse('No scripts found');
+    }
+    return successResponse(scripts.join('\n'));
+  } catch (error) {
+    return errorResponse(error as Error);
+  }
+}
+
+export async function handleGetScriptSource(args: unknown): Promise<McpToolResponse> {
+  try {
+    const { scriptUrl } = args as { scriptUrl: string };
+    const { getFirefox } = await import('../index.js');
+    const firefox = await getFirefox();
+    requireDebuggingSupport(firefox);
+    const contextId = requireContext(firefox.getCurrentContextId());
+    const result = await firefox.sendBiDiCommand('moz:debugging.getScriptSource', {
+      context: contextId,
+      scriptUrl,
+    });
+    return successResponse((result as { source: string }).source);
+  } catch (error) {
+    return errorResponse(error as Error);
+  }
+}
+
+export async function handleSetLogpoint(args: unknown): Promise<McpToolResponse> {
+  try {
+    const { url, line, expression } = args as { url: string; line: number; expression: string };
+    const { getFirefox } = await import('../index.js');
+    const firefox = await getFirefox();
+    requireDebuggingSupport(firefox);
+    const logpointId = await firefox.setLogpoint(url, line, expression);
+    return successResponse(`Logpoint set (id: ${logpointId})`);
+  } catch (error) {
+    return errorResponse(error as Error);
+  }
+}
+
+export async function handleRemoveLogpoint(args: unknown): Promise<McpToolResponse> {
+  try {
+    const { logpoint } = args as { logpoint: string };
+    const { getFirefox } = await import('../index.js');
+    const firefox = await getFirefox();
+    requireDebuggingSupport(firefox);
+    await firefox.removeLogpoint(logpoint);
+    return successResponse('Logpoint removed');
+  } catch (error) {
+    return errorResponse(error as Error);
+  }
+}
+
+export async function handleGetLogpointResults(args: unknown): Promise<McpToolResponse> {
+  try {
+    const { logpoint } = args as { logpoint: string };
+    const { getFirefox } = await import('../index.js');
+    const firefox = await getFirefox();
+    requireDebuggingSupport(firefox);
+    const results = firefox.getLogpointResults(logpoint);
+    if (results === null) {
+      return errorResponse(new Error(`Logpoint ${logpoint} not found`));
+    }
+    if (results.length === 0) {
+      return successResponse('No results collected yet');
+    }
+    const lines = results.map((r, i) => {
+      if (r.error) {
+        return `[${i + 1}] Error: ${r.error}`;
+      }
+      return `[${i + 1}] ${JSON.stringify(remoteValueToNative(r.value))}`;
+    });
+    return successResponse(lines.join('\n'));
+  } catch (error) {
+    return errorResponse(error as Error);
+  }
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -118,3 +118,19 @@ export {
   handleUninstallExtension,
   handleListExtensions,
 } from './webextension.js';
+
+// Debugging tools (script inspection, logpoints)
+export {
+  enableDebuggerTool,
+  listScriptsTool,
+  getScriptSourceTool,
+  setLogpointTool,
+  removeLogpointTool,
+  getLogpointResultsTool,
+  handleEnableDebugger,
+  handleListScripts,
+  handleGetScriptSource,
+  handleSetLogpoint,
+  handleRemoveLogpoint,
+  handleGetLogpointResults,
+} from './debugging.js';

--- a/tests/firefox/events/debugging.test.ts
+++ b/tests/firefox/events/debugging.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DebuggingEvents } from '../../../src/firefox/events/debugging.js';
+
+function makeMockDriver() {
+  const handlers: Record<string, Function[]> = {};
+  const mockWs = {
+    on: vi.fn((event: string, fn: Function) => {
+      (handlers[event] ??= []).push(fn);
+    }),
+  };
+  const mockBidi = {
+    subscribe: vi.fn().mockResolvedValue(undefined),
+    socket: mockWs,
+  };
+  return {
+    driver: { getBidi: vi.fn().mockResolvedValue(mockBidi) } as any,
+    mockBidi,
+    mockWs,
+    emit: (payload: unknown) => handlers['message']?.forEach((h) => h(JSON.stringify(payload))),
+  };
+}
+
+describe('DebuggingEvents', () => {
+  let mock: ReturnType<typeof makeMockDriver>;
+  let sendBiDiCommand: ReturnType<typeof vi.fn>;
+  let events: DebuggingEvents;
+
+  beforeEach(() => {
+    mock = makeMockDriver();
+    sendBiDiCommand = vi
+      .fn()
+      .mockResolvedValue({ type: 'success', result: { type: 'string', value: 'ok' } });
+    events = new DebuggingEvents(mock.driver, sendBiDiCommand);
+  });
+
+  it('subscribe called twice only attaches one WebSocket listener', async () => {
+    await events.subscribe();
+    await events.subscribe();
+    expect(mock.mockWs.on).toHaveBeenCalledTimes(1);
+  });
+
+  it('subscribe does not throw when bidi.subscribe rejects', async () => {
+    mock.mockBidi.subscribe.mockRejectedValue(new Error('unsupported event'));
+    await expect(events.subscribe()).resolves.not.toThrow();
+  });
+
+  describe('logpoints', () => {
+    const LOGPOINT_ID = 'bp-1';
+    const URL = 'https://example.com/script.js';
+    const LINE = 10;
+
+    beforeEach(async () => {
+      await events.subscribe();
+    });
+
+    it('getLogpointResults returns null for unknown logpoint', () => {
+      expect(events.getLogpointResults('unknown')).toBeNull();
+    });
+
+    it('getLogpointResults returns empty array before any hit', () => {
+      events.addLogpoint(LOGPOINT_ID, URL, LINE, 'x');
+      expect(events.getLogpointResults(LOGPOINT_ID)).toEqual([]);
+    });
+
+    it('removeLogpoint clears results', () => {
+      events.addLogpoint(LOGPOINT_ID, URL, LINE, 'x');
+      events.removeLogpoint(LOGPOINT_ID);
+      expect(events.getLogpointResults(LOGPOINT_ID)).toBeNull();
+    });
+
+    it('pause at logpoint location evaluates expression and resumes', async () => {
+      events.addLogpoint(LOGPOINT_ID, URL, LINE, 'x + 1');
+      mock.emit({
+        method: 'moz:debugging.paused',
+        params: { context: 'ctx-1', url: URL, line: LINE, column: 0, callFrames: [] },
+      });
+
+      await vi.waitFor(() =>
+        expect(sendBiDiCommand).toHaveBeenCalledWith(
+          'script.evaluate',
+          expect.objectContaining({ expression: 'x + 1' })
+        )
+      );
+      await vi.waitFor(() =>
+        expect(sendBiDiCommand).toHaveBeenCalledWith('moz:debugging.resume', { context: 'ctx-1' })
+      );
+
+      const results = events.getLogpointResults(LOGPOINT_ID)!;
+      expect(results).toHaveLength(1);
+      expect(results[0].error).toBeUndefined();
+    });
+
+    it('stores error result when expression evaluation throws', async () => {
+      sendBiDiCommand.mockResolvedValueOnce({
+        type: 'exception',
+        exceptionDetails: { text: 'ReferenceError: x is not defined' },
+      });
+      events.addLogpoint(LOGPOINT_ID, URL, LINE, 'x');
+      mock.emit({
+        method: 'moz:debugging.paused',
+        params: { context: 'ctx-1', url: URL, line: LINE, column: 0, callFrames: [] },
+      });
+
+      await vi.waitFor(() => {
+        const results = events.getLogpointResults(LOGPOINT_ID)!;
+        return results.length > 0;
+      });
+
+      const results = events.getLogpointResults(LOGPOINT_ID)!;
+      expect(results[0].error).toBe('ReferenceError: x is not defined');
+    });
+
+    it('pause at non-logpoint location does not evaluate expression', async () => {
+      events.addLogpoint(LOGPOINT_ID, URL, LINE, 'x');
+      mock.emit({
+        method: 'moz:debugging.paused',
+        params: { context: 'ctx-1', url: URL, line: 99, column: 0, callFrames: [] },
+      });
+
+      await new Promise((r) => setTimeout(r, 20));
+      expect(sendBiDiCommand).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/firefox/events/debugging.test.ts
+++ b/tests/firefox/events/debugging.test.ts
@@ -110,6 +110,24 @@ describe('DebuggingEvents', () => {
       expect(results[0].error).toBe('ReferenceError: x is not defined');
     });
 
+    it('result buffer is capped at 100, dropping oldest results first', async () => {
+      events.addLogpoint(LOGPOINT_ID, URL, LINE, 'x');
+
+      for (let i = 0; i < 105; i++) {
+        mock.emit({
+          method: 'moz:debugging.paused',
+          params: { context: 'ctx-1', url: URL, line: LINE, column: 0, callFrames: [] },
+        });
+      }
+
+      await vi.waitFor(
+        () => {
+          expect(events.getLogpointResults(LOGPOINT_ID)).toHaveLength(100);
+        },
+        { timeout: 1000 }
+      );
+    });
+
     it('pause at non-logpoint location does not evaluate expression', async () => {
       events.addLogpoint(LOGPOINT_ID, URL, LINE, 'x');
       mock.emit({


### PR DESCRIPTION
At the moment full breakpoint support is not easy to integrate with the mcp, because it breaks many tools. Instead having logpoints allows the mcp to collect information while running a scenario without breaking the execution.

Ideally the logpoint feature would be built in webdriver-bidi but for the time being we prototype the feature in the MCP layer.

The MCP will set breakpoints and send script.evaluate commands to capture logpoint data, which can be queried out of band by the client.