### PR TITLE
Bug 2052552 - feature: add --auto-profile option to automatically reuse a profile folder across runs

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -14,8 +14,10 @@
       "args": [
         "-y",
         "@mozilla/firefox-devtools-mcp@latest",
+        "--auto-profile",
         "--enable-script",
-        "--pref", "remote.prefs.recommended=false"
+        "--pref",
+        "remote.prefs.recommended=false"
       ]
     }
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,9 @@
  * CLI argument parsing for Firefox DevTools MCP server
  */
 
+import { createHash } from 'node:crypto';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 import type { Options as YargsOptions } from 'yargs';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
@@ -10,6 +13,20 @@ import { hideBin } from 'yargs/helpers';
  * Parsed preference value (boolean, integer, or string)
  */
 export type PrefValue = string | number | boolean;
+
+/**
+ * Returns the default profile parent directory for --auto-profile mode.
+ * When a Firefox binary path is given, a short hash of that path is appended
+ * so that different builds (Release, Nightly, …) each get their own profile.
+ */
+export function defaultProfileDir(firefoxPath?: string): string {
+  const base = join(homedir(), '.firefox-devtools-mcp');
+  if (!firefoxPath) {
+    return join(base, 'profile');
+  }
+  const hash = createHash('sha1').update(firefoxPath).digest('hex').slice(0, 8);
+  return join(base, `profile-${hash}`);
+}
 
 /**
  * Parse preference strings into typed values
@@ -88,6 +105,14 @@ export const cliOptions = {
   profilePath: {
     type: 'string',
     description: 'Path to Firefox profile directory (optional, for persistent profile)',
+  },
+  autoProfile: {
+    type: 'boolean',
+    description:
+      'Automatically use a persistent profile stored in ~/.firefox-devtools-mcp/. ' +
+      'When --firefox-path is set, the profile is scoped to that binary so different ' +
+      'Firefox builds stay isolated.',
+    default: (process.env.AUTO_PROFILE ?? 'false') === 'true',
   },
   firefoxArg: {
     type: 'array',

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import {
 
 import { SERVER_NAME, SERVER_VERSION } from './config/constants.js';
 import { log, logError, logDebug, setupLogFile, flushLogs } from './utils/logger.js';
-import { parsePrefs } from './cli.js';
+import { parsePrefs, defaultProfileDir } from './cli.js';
 import type { parseArguments } from './cli.js';
 import { FirefoxDevTools } from './firefox/index.js';
 import type { FirefoxLaunchOptions } from './firefox/types.js';
@@ -119,7 +119,8 @@ export async function getFirefox(): Promise<FirefoxDevTools> {
     options = {
       firefoxPath: args.firefoxPath ?? undefined,
       headless: args.headless,
-      profilePath: args.profilePath ?? undefined,
+      profilePath:
+        args.profilePath ?? (args.autoProfile ? defaultProfileDir(args.firefoxPath) : undefined),
       viewport: args.viewport ?? undefined,
       args: (args.firefoxArg as string[] | undefined) ?? undefined,
       startUrl: args.startUrl ?? undefined,

--- a/tests/cli/prefs-parsing.test.ts
+++ b/tests/cli/prefs-parsing.test.ts
@@ -2,8 +2,37 @@
  * Tests for preference parsing (parsePrefs function) and CLI --pref option
  */
 
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
 import { describe, it, expect } from 'vitest';
-import { parsePrefs, parseArguments } from '../../src/cli.js';
+import { parsePrefs, parseArguments, defaultProfileDir } from '../../src/cli.js';
+
+describe('defaultProfileDir', () => {
+  const base = join(homedir(), '.firefox-devtools-mcp');
+
+  it('returns base profile dir when no firefox path given', () => {
+    expect(defaultProfileDir()).toBe(join(base, 'profile'));
+    expect(defaultProfileDir(undefined)).toBe(join(base, 'profile'));
+  });
+
+  it('appends an 8-char hash of the binary path', () => {
+    const binaryPath = '/Applications/Firefox.app/Contents/MacOS/firefox';
+    const hash = createHash('sha1').update(binaryPath).digest('hex').slice(0, 8);
+    expect(defaultProfileDir(binaryPath)).toBe(join(base, `profile-${hash}`));
+  });
+
+  it('produces different dirs for different binaries', () => {
+    const release = defaultProfileDir('/usr/bin/firefox');
+    const nightly = defaultProfileDir('/opt/firefox-nightly/firefox');
+    expect(release).not.toBe(nightly);
+  });
+
+  it('produces the same dir for the same binary path', () => {
+    const path = '/usr/bin/firefox';
+    expect(defaultProfileDir(path)).toBe(defaultProfileDir(path));
+  });
+});
 
 describe('parsePrefs', () => {
   it('should return empty object for undefined input', () => {


### PR DESCRIPTION
Passing --auto-profile will let the firefox-devtools-mcp pick a profile folder based on the binary path used to start Firefox. Infering the folder name from the binary path reduces the risk of using a profile created for Firefox Nightly with eg Firefox Beta or Release. 

This remains an opt in feature, but set by default in the plugin definition. 