### PR TITLE
Bug 2056469, Bug 2056470 - fix connect-existing docs and throw explicit error for sessions without BiDi

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,19 +141,17 @@ Port forwarding between the host and device is handled automatically by geckodri
 
 ### Connect to existing Firefox
 
-Use `--connect-existing` to automate your real browsing session — with cookies, logins, and open tabs intact:
+Use `--connect-existing` to automate your real browsing session, with cookies, logins, and open tabs intact:
 
 ```bash
-# Start Firefox with Marionette enabled
-firefox --marionette
+# Start Firefox with Marionette and the Remote Agent (BiDi)
+firefox --marionette --remote-debugging-port
 
 # Run the MCP server
 npx @mozilla/firefox-devtools-mcp --connect-existing --marionette-port 2828
 ```
 
-Or set `marionette.enabled` to `true` in `about:config` (or `user.js`) to enable Marionette on every launch.
-
-BiDi-dependent features (console events, network events) are not available in connect-existing mode; all other features work normally.
+Both flags are required. `--marionette` lets the MCP attach to the running Firefox, and `--remote-debugging-port` starts the Remote Agent that provides the WebDriver BiDi endpoint used by navigation, console, and network tools. Setting `marionette.enabled` in `about:config` or `user.js` is not sufficient on its own, because the Remote Agent only starts when the command line flag is passed. If Firefox is running without it, the MCP server fails to connect and asks you to restart Firefox with both flags.
 
 > **Warning:** Do not leave Marionette enabled during normal browsing. It sets
 > `navigator.webdriver = true` and changes other browser fingerprint signals,

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ firefox --marionette --remote-debugging-port
 npx @mozilla/firefox-devtools-mcp --connect-existing --marionette-port 2828
 ```
 
-Both flags are required. `--marionette` lets the MCP attach to the running Firefox, and `--remote-debugging-port` starts the Remote Agent that provides the WebDriver BiDi endpoint used by navigation, console, and network tools. Setting `marionette.enabled` in `about:config` or `user.js` is not sufficient on its own, because the Remote Agent only starts when the command line flag is passed. If Firefox is running without it, the MCP server fails to connect and asks you to restart Firefox with both flags.
+Both flags are required because the MCP uses both WebDriver Classic (`--marionette`) and WebDriver BiDi (`--remote-debugging-port`). If Firefox is only started with `--marionette`, the MCP server fails to connect and asks you to restart Firefox with both flags.
 
 > **Warning:** Do not leave Marionette enabled during normal browsing. It sets
 > `navigator.webdriver = true` and changes other browser fingerprint signals,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -127,7 +127,7 @@ export const cliOptions = {
   connectExisting: {
     type: 'boolean',
     description:
-      'Connect to an already-running Firefox instance via Marionette instead of launching a new one. Requires Firefox to be running with marionette.enabled=true (set in user.js or launched with --marionette).',
+      'Connect to an already-running Firefox instance via Marionette instead of launching a new one. Firefox must be started with both --marionette and --remote-debugging-port; the BiDi endpoint is required for navigation, console, and network tools.',
     default: (process.env.CONNECT_EXISTING ?? 'false') === 'true',
   },
   marionettePort: {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -127,7 +127,7 @@ export const cliOptions = {
   connectExisting: {
     type: 'boolean',
     description:
-      'Connect to an already-running Firefox instance via Marionette instead of launching a new one. Firefox must be started with both --marionette and --remote-debugging-port; the BiDi endpoint is required for navigation, console, and network tools.',
+      'Connect to an already-running Firefox instance via Marionette instead of launching a new one. Firefox must be started with both --marionette and --remote-debugging-port.',
     default: (process.env.CONNECT_EXISTING ?? 'false') === 'true',
   },
   marionettePort: {

--- a/src/firefox/core.ts
+++ b/src/firefox/core.ts
@@ -279,6 +279,19 @@ export class FirefoxCore {
     this.firefoxVersion = (driverCapabilities.get('browserVersion') as string) ?? null;
     logDebug(`Browser version: ${this.firefoxVersion}`);
 
+    // In connect-existing mode, geckodriver can attach to a Firefox that was
+    // started with --marionette but without --remote-debugging-port. Marionette
+    // works, but the session has no BiDi endpoint, so most tools would later
+    // fail with confusing errors. Detect this early with an actionable message.
+    if (this.options.connectExisting && !driverCapabilities.get('webSocketUrl')) {
+      throw new Error(
+        'Connected to Firefox via Marionette, but the session has no WebDriver BiDi endpoint ' +
+          '(missing webSocketUrl capability). Restart Firefox with both flags: ' +
+          'firefox --marionette --remote-debugging-port. ' +
+          'Navigation, console, and network tools require BiDi.'
+      );
+    }
+
     // Remember current window handle (browsing context)
     this.currentContextId = await this.driver.getWindowHandle();
     logDebug(`Browsing context ID: ${this.currentContextId}`);

--- a/src/firefox/core.ts
+++ b/src/firefox/core.ts
@@ -287,8 +287,7 @@ export class FirefoxCore {
       throw new Error(
         'Connected to Firefox via Marionette, but the session has no WebDriver BiDi endpoint ' +
           '(missing webSocketUrl capability). Restart Firefox with both flags: ' +
-          'firefox --marionette --remote-debugging-port. ' +
-          'Navigation, console, and network tools require BiDi.'
+          'firefox --marionette --remote-debugging-port.'
       );
     }
 

--- a/src/firefox/index.ts
+++ b/src/firefox/index.ts
@@ -92,7 +92,7 @@ export class FirefoxClient {
       try {
         await this.consoleEvents.subscribe(undefined);
       } catch {
-        logDebug('Console events unavailable (BiDi not supported by this Firefox session)');
+        logDebug('Unable to subscribe to console events');
         this.consoleEvents = null;
       }
     }
@@ -100,7 +100,7 @@ export class FirefoxClient {
       try {
         await this.networkEvents.subscribe(undefined);
       } catch {
-        logDebug('Network events unavailable (BiDi not supported by this Firefox session)');
+        logDebug('Unable to subscribe to network events');
         this.networkEvents = null;
       }
     }
@@ -108,7 +108,7 @@ export class FirefoxClient {
       try {
         await this.debuggingEvents.subscribe();
       } catch {
-        logDebug('Debugging events unavailable (BiDi not supported by this Firefox session)');
+        logDebug('Unable to subscribe to debugging events');
         this.debuggingEvents = null;
       }
     }

--- a/tests/firefox/connect-existing.test.ts
+++ b/tests/firefox/connect-existing.test.ts
@@ -2,7 +2,7 @@
  * Tests for connect-existing mode (FirefoxCore behaviour)
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 describe('getFirefox() reconnect behavior', () => {
   it('should reconnect when connection is lost instead of throwing', async () => {
@@ -41,5 +41,126 @@ describe('getFirefox() reconnect behavior', () => {
     await core.close();
     expect(core.getCurrentContextId()).toBe(null);
     expect(() => core.getDriver()).toThrow('Driver not connected');
+  });
+});
+
+// Tests for the BiDi endpoint check in connect-existing mode (Bug 2056470)
+describe('FirefoxCore connect() BiDi endpoint check', () => {
+  // Mocks for the connect-existing path
+  const mockServiceAddArguments = vi.fn();
+  const mockServiceBuild = vi.fn().mockReturnValue({});
+  const mockCreateSession = vi.fn();
+  const mockCapabilitiesSet = vi.fn();
+
+  // Mocks for the launch path (used by the launch-mode test only)
+  const mockEnableBidi = vi.fn();
+  const mockOptionsAddArguments = vi.fn();
+
+  // Builds a mock WebDriver whose getCapabilities() resolves to a
+  // Capabilities-like object backed by the given values.
+  const makeDriver = (capabilityValues: Record<string, unknown>) => ({
+    getCapabilities: vi.fn().mockResolvedValue({
+      get: vi.fn((name: string) => capabilityValues[name]),
+    }),
+    getWindowHandle: vi.fn().mockResolvedValue('mock-context-id'),
+    get: vi.fn().mockResolvedValue(undefined),
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+
+    vi.doMock('selenium-webdriver/firefox.js', () => ({
+      default: {
+        Options: class {
+          enableBidi = mockEnableBidi;
+          addArguments = mockOptionsAddArguments;
+          windowSize = vi.fn();
+          setBinary = vi.fn();
+          setProfile = vi.fn();
+          setAcceptInsecureCerts = vi.fn();
+          setPreference = vi.fn();
+        },
+        ServiceBuilder: class {
+          addArguments = mockServiceAddArguments;
+          build = mockServiceBuild;
+          setStdio = vi.fn();
+        },
+        Driver: { createSession: mockCreateSession },
+      },
+    }));
+
+    vi.doMock('selenium-webdriver', () => ({
+      Capabilities: class {
+        set = mockCapabilitiesSet;
+      },
+      Builder: class {
+        forBrowser = vi.fn().mockReturnThis();
+        setFirefoxOptions = vi.fn().mockReturnThis();
+        setFirefoxService = vi.fn().mockReturnThis();
+        build = vi.fn().mockResolvedValue(makeDriver({ browserVersion: '142.0' }));
+      },
+      Browser: { FIREFOX: 'firefox' },
+    }));
+
+    // existsSync returns true for geckodriver paths so findGeckodriver() succeeds.
+    vi.doMock('node:fs', () => ({
+      existsSync: vi.fn((p: unknown) => String(p).includes('geckodriver')),
+      mkdirSync: vi.fn(),
+      copyFileSync: vi.fn(),
+      openSync: vi.fn().mockReturnValue(3),
+      closeSync: vi.fn(),
+      readdirSync: vi.fn().mockReturnValue([]),
+      statSync: vi.fn(),
+    }));
+  });
+
+  it('should reject with an actionable error when the session has no webSocketUrl', async () => {
+    const driver = makeDriver({ browserVersion: '142.0' });
+    mockCreateSession.mockReturnValue(driver);
+
+    const { FirefoxCore } = await import('@/firefox/core.js');
+    const core = new FirefoxCore({ connectExisting: true, marionettePort: 2828 });
+
+    const connectPromise = core.connect();
+    await expect(connectPromise).rejects.toThrow(/webSocketUrl/);
+    await expect(connectPromise).rejects.toThrow('--marionette --remote-debugging-port');
+
+    // The check fires before any further driver interaction
+    expect(driver.getWindowHandle).not.toHaveBeenCalled();
+  });
+
+  it('should connect normally when the session has a webSocketUrl', async () => {
+    const driver = makeDriver({
+      browserVersion: '142.0',
+      webSocketUrl: 'ws://127.0.0.1:9222/session/abc',
+    });
+    mockCreateSession.mockReturnValue(driver);
+
+    const { FirefoxCore } = await import('@/firefox/core.js');
+    const core = new FirefoxCore({ connectExisting: true, marionettePort: 2828 });
+
+    await core.connect();
+
+    expect(mockCreateSession).toHaveBeenCalledTimes(1);
+    expect(mockServiceAddArguments).toHaveBeenCalledWith(
+      '--connect-existing',
+      '--marionette-port=2828'
+    );
+    expect(mockCapabilitiesSet).toHaveBeenCalledWith('webSocketUrl', true);
+    expect(core.getFirefoxVersion()).toBe('142.0');
+    expect(core.getCurrentContextId()).toBe('mock-context-id');
+  });
+
+  it('should not apply the check in launch mode', async () => {
+    // The Builder mock returns a driver without webSocketUrl; launch mode
+    // must still connect because the check is connect-existing only.
+    const { FirefoxCore } = await import('@/firefox/core.js');
+    const core = new FirefoxCore({ headless: true });
+
+    await core.connect();
+
+    expect(mockCreateSession).not.toHaveBeenCalled();
+    expect(core.getCurrentContextId()).toBe('mock-context-id');
   });
 });


### PR DESCRIPTION
## Summary

Repurposed per the review discussion. Two changes:

1. README and CLI help: connect-existing now documents starting Firefox with both `--marionette` and `--remote-debugging-port`, and no longer claims console/network events are unavailable in this mode.
2. When `--connect-existing` attaches to a session without a `webSocketUrl` capability, the server fails the connect with an error saying which flags to relaunch with, instead of tools failing later with `Cannot read properties of undefined (reading 'replace')`.

The classic-navigation fallback from the first version of this PR is gone.

## Testing

- typecheck, lint, build, and the vitest suite pass; added unit tests for the new check (missing capability, present capability, launch mode untouched).
- Manually verified on Windows 11 / Firefox 152.0.6 against the built server over stdio: with both flags all tools work; with `--marionette` alone every tool call now fails immediately with the new message.
