### PR TITLE
Bug 2056201 - [firefox-devtools-mcp] Add readonly hints to MCP tools which don't modify the state

### DIFF
--- a/src/tools/console.ts
+++ b/src/tools/console.ts
@@ -14,6 +14,9 @@ import type { McpToolResponse } from '../types/common.js';
 export const listConsoleMessagesTool = {
   name: 'list_console_messages',
   description: 'List console messages. Supports filtering by level, time, text, source.',
+  annotations: {
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -50,6 +53,9 @@ export const listConsoleMessagesTool = {
 export const clearConsoleMessagesTool = {
   name: 'clear_console_messages',
   description: 'Clear collected console messages.',
+  annotations: {
+    readOnlyHint: false,
+  },
   inputSchema: {
     type: 'object',
     properties: {},

--- a/src/tools/debugging.ts
+++ b/src/tools/debugging.ts
@@ -29,6 +29,9 @@ export const enableDebuggerTool = {
   name: 'enable_debugger',
   description:
     'Enable the JS debugger for the current page. Required before set_logpoint works. Requires Firefox 153+.',
+  annotations: {
+    readOnlyHint: false,
+  },
   inputSchema: { type: 'object', properties: {} },
 };
 
@@ -36,6 +39,9 @@ export const listScriptsTool = {
   name: 'list_scripts',
   description:
     'List all JavaScript files currently loaded in the page. Requires enable_debugger to have been called.',
+  annotations: {
+    readOnlyHint: true,
+  },
   inputSchema: { type: 'object', properties: {} },
 };
 
@@ -43,6 +49,9 @@ export const getScriptSourceTool = {
   name: 'get_script_source',
   description:
     'Get the source code of a JavaScript file loaded in the page. Requires enable_debugger to have been called.',
+  annotations: {
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -56,6 +65,9 @@ export const setLogpointTool = {
   name: 'set_logpoint',
   description:
     'Set a logpoint at a specific location. When execution reaches that line, the expression is evaluated and the result is stored without pausing. Use get_logpoint_results to retrieve collected values. Requires enable_debugger to have been called.',
+  annotations: {
+    readOnlyHint: false,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -73,6 +85,9 @@ export const setLogpointTool = {
 export const removeLogpointTool = {
   name: 'remove_logpoint',
   description: 'Remove a previously set logpoint.',
+  annotations: {
+    readOnlyHint: false,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -85,6 +100,9 @@ export const removeLogpointTool = {
 export const getLogpointResultsTool = {
   name: 'get_logpoint_results',
   description: 'Get the results collected by a logpoint since it was set.',
+  annotations: {
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {

--- a/src/tools/firefox-management.ts
+++ b/src/tools/firefox-management.ts
@@ -21,6 +21,9 @@ export const getFirefoxLogsTool = {
   name: 'get_firefox_output',
   description:
     'Retrieve Firefox output (stdout/stderr including MOZ_LOG, warnings, crashes, stack traces). Returns recent output from the capture file. Use filters to focus on specific content.',
+  annotations: {
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -116,6 +119,9 @@ export const getFirefoxInfoTool = {
   name: 'get_firefox_info',
   description:
     'Get information about the current Firefox instance configuration, including binary path, environment variables, and output file location.',
+  annotations: {
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {},
@@ -196,6 +202,9 @@ export const restartFirefoxTool = {
   name: 'restart_firefox',
   description:
     'Restart Firefox with different configuration. Allows changing binary path, environment variables, and other options. All current tabs will be closed.',
+  annotations: {
+    readOnlyHint: false,
+  },
   inputSchema: {
     type: 'object',
     properties: {

--- a/src/tools/firefox-prefs.ts
+++ b/src/tools/firefox-prefs.ts
@@ -16,6 +16,9 @@ export const setFirefoxPrefsTool = {
   name: 'set_firefox_prefs',
   description:
     'Set Firefox preferences at runtime a privileged API. Requires MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1 env var.',
+  annotations: {
+    readOnlyHint: false,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -127,6 +130,9 @@ export const getFirefoxPrefsTool = {
   name: 'get_firefox_prefs',
   description:
     'Get Firefox preference values via a privileged API. Requires MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1 env var.',
+  annotations: {
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {

--- a/src/tools/input.ts
+++ b/src/tools/input.ts
@@ -11,6 +11,9 @@ import type { McpToolResponse } from '../types/common.js';
 export const clickByUidTool = {
   name: 'click_by_uid',
   description: 'Click element by UID. Set dblClick for double-click.',
+  annotations: {
+    readOnlyHint: false,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -30,6 +33,9 @@ export const clickByUidTool = {
 export const hoverByUidTool = {
   name: 'hover_by_uid',
   description: 'Hover over element by UID.',
+  annotations: {
+    readOnlyHint: false,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -45,6 +51,9 @@ export const hoverByUidTool = {
 export const fillByUidTool = {
   name: 'fill_by_uid',
   description: 'Fill text input/textarea by UID.',
+  annotations: {
+    readOnlyHint: false,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -64,6 +73,9 @@ export const fillByUidTool = {
 export const dragByUidToUidTool = {
   name: 'drag_by_uid_to_uid',
   description: 'Drag element to another (HTML5 drag events).',
+  annotations: {
+    readOnlyHint: false,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -83,6 +95,9 @@ export const dragByUidToUidTool = {
 export const fillFormByUidTool = {
   name: 'fill_form_by_uid',
   description: 'Fill multiple form fields at once.',
+  annotations: {
+    readOnlyHint: false,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -112,6 +127,9 @@ export const fillFormByUidTool = {
 export const uploadFileByUidTool = {
   name: 'upload_file_by_uid',
   description: 'Upload file to file input by UID.',
+  annotations: {
+    readOnlyHint: false,
+  },
   inputSchema: {
     type: 'object',
     properties: {

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -15,6 +15,9 @@ import type { McpToolResponse } from '../types/common.js';
 export const listNetworkRequestsTool = {
   name: 'list_network_requests',
   description: 'List network requests. Returns IDs for get_network_request.',
+  annotations: {
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object' as const,
     properties: {
@@ -76,6 +79,9 @@ export const listNetworkRequestsTool = {
 export const getNetworkRequestTool = {
   name: 'get_network_request',
   description: 'Get request details by ID. URL lookup as fallback.',
+  annotations: {
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object' as const,
     properties: {

--- a/src/tools/pages.ts
+++ b/src/tools/pages.ts
@@ -9,6 +9,9 @@ import type { McpToolResponse } from '../types/common.js';
 export const listPagesTool = {
   name: 'list_pages',
   description: 'List open tabs (index, title, URL). Selected tab is marked.',
+  annotations: {
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {},
@@ -18,6 +21,9 @@ export const listPagesTool = {
 export const newPageTool = {
   name: 'new_page',
   description: 'Open new tab at URL. Returns tab index.',
+  annotations: {
+    readOnlyHint: false,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -33,6 +39,9 @@ export const newPageTool = {
 export const navigatePageTool = {
   name: 'navigate_page',
   description: 'Navigate selected tab to URL.',
+  annotations: {
+    readOnlyHint: false,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -48,6 +57,9 @@ export const navigatePageTool = {
 export const selectPageTool = {
   name: 'select_page',
   description: 'Select active tab by index, URL, or title. Index takes precedence.',
+  annotations: {
+    readOnlyHint: false,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -71,6 +83,9 @@ export const selectPageTool = {
 export const closePageTool = {
   name: 'close_page',
   description: 'Close tab by index.',
+  annotations: {
+    readOnlyHint: false,
+  },
   inputSchema: {
     type: 'object',
     properties: {

--- a/src/tools/privileged-context.ts
+++ b/src/tools/privileged-context.ts
@@ -12,6 +12,9 @@ export const listPrivilegedContextsTool = {
   name: 'list_privileged_contexts',
   description:
     'List privileged (privileged) browsing contexts. Requires MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1 env var. Use restart_firefox with env parameter to enable.',
+  annotations: {
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {},
@@ -22,6 +25,9 @@ export const selectPrivilegedContextTool = {
   name: 'select_privileged_context',
   description:
     'Select a privileged browsing context by ID and set WebDriver Classic context to "chrome" . Requires MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1 env var.',
+  annotations: {
+    readOnlyHint: false,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -38,6 +44,9 @@ export const evaluatePrivilegedScriptTool = {
   name: 'evaluate_privileged_script',
   description:
     'Execute JS function in the current privileged context. Requires MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1 env var. Use select_privileged_context first to target a chrome context.',
+  annotations: {
+    readOnlyHint: false,
+  },
   inputSchema: {
     type: 'object',
     properties: {

--- a/src/tools/profiler.ts
+++ b/src/tools/profiler.ts
@@ -32,6 +32,9 @@ const VALID_PRESETS = [
 export const profilerIsActiveTool = {
   name: 'profiler_is_active',
   description: 'Check whether the Firefox profiler is currently recording.',
+  annotations: {
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {},
@@ -59,6 +62,9 @@ export async function handleProfilerIsActive(_args: unknown): Promise<McpToolRes
 export const profilerStartTool = {
   name: 'profiler_start',
   description: `Start the Firefox profiler. Provide either a preset name or explicit recording options (entries, interval, features, threads). Cannot combine both. Valid presets: ${VALID_PRESETS.join(', ')}.`,
+  annotations: {
+    readOnlyHint: false,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -152,6 +158,9 @@ export const profilerStopTool = {
   name: 'profiler_stop',
   description:
     'Stop the Firefox profiler and save the recorded profile to a file in the downloads directory. Returns the path to the saved file, or null when nothing was saved.',
+  annotations: {
+    readOnlyHint: false,
+  },
   inputSchema: {
     type: 'object',
     properties: {

--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -18,6 +18,9 @@ const SAVE_TO_SCHEMA = {
 export const screenshotPageTool = {
   name: 'screenshot_page',
   description: 'Capture page screenshot as base64 PNG.',
+  annotations: {
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -29,6 +32,9 @@ export const screenshotPageTool = {
 export const screenshotByUidTool = {
   name: 'screenshot_by_uid',
   description: 'Capture element screenshot by UID as base64 PNG.',
+  annotations: {
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {

--- a/src/tools/script.ts
+++ b/src/tools/script.ts
@@ -10,6 +10,9 @@ import type { McpToolResponse } from '../types/common.js';
 export const evaluateScriptTool = {
   name: 'evaluate_script',
   description: 'Execute JS function in page. Prefer UID tools for interactions.',
+  annotations: {
+    readOnlyHint: false,
+  },
   inputSchema: {
     type: 'object',
     properties: {

--- a/src/tools/snapshot.ts
+++ b/src/tools/snapshot.ts
@@ -12,6 +12,9 @@ const DEFAULT_SNAPSHOT_LINES = 100;
 export const takeSnapshotTool = {
   name: 'take_snapshot',
   description: 'Capture DOM snapshot with stable UIDs. Retake after navigation.',
+  annotations: {
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -47,6 +50,9 @@ export const takeSnapshotTool = {
 export const resolveUidToSelectorTool = {
   name: 'resolve_uid_to_selector',
   description: 'Resolve UID to CSS selector. Fails if stale.',
+  annotations: {
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -62,6 +68,9 @@ export const resolveUidToSelectorTool = {
 export const clearSnapshotTool = {
   name: 'clear_snapshot',
   description: 'Clear snapshot cache. Usually not needed.',
+  annotations: {
+    readOnlyHint: false,
+  },
   inputSchema: {
     type: 'object',
     properties: {},

--- a/src/tools/utilities.ts
+++ b/src/tools/utilities.ts
@@ -9,6 +9,9 @@ import type { McpToolResponse } from '../types/common.js';
 export const acceptDialogTool = {
   name: 'accept_dialog',
   description: 'Accept browser dialog. Provide promptText for prompts.',
+  annotations: {
+    readOnlyHint: false,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -23,6 +26,9 @@ export const acceptDialogTool = {
 export const dismissDialogTool = {
   name: 'dismiss_dialog',
   description: 'Dismiss browser dialog.',
+  annotations: {
+    readOnlyHint: false,
+  },
   inputSchema: {
     type: 'object',
     properties: {},
@@ -33,6 +39,9 @@ export const dismissDialogTool = {
 export const navigateHistoryTool = {
   name: 'navigate_history',
   description: 'Navigate history back/forward. UIDs become stale.',
+  annotations: {
+    readOnlyHint: false,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -50,6 +59,9 @@ export const navigateHistoryTool = {
 export const setViewportSizeTool = {
   name: 'set_viewport_size',
   description: 'Set viewport dimensions in pixels.',
+  annotations: {
+    readOnlyHint: false,
+  },
   inputSchema: {
     type: 'object',
     properties: {

--- a/src/tools/webextension.ts
+++ b/src/tools/webextension.ts
@@ -20,6 +20,9 @@ export const installExtensionTool = {
   name: 'install_extension',
   description:
     'Install a Firefox extension using WebDriver BiDi webExtension.install command. Supports installing from archive (.xpi/.zip), base64-encoded data, or unpacked directory.',
+  annotations: {
+    readOnlyHint: false,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -107,6 +110,9 @@ export const uninstallExtensionTool = {
   name: 'uninstall_extension',
   description:
     'Uninstall a Firefox extension using WebDriver BiDi webExtension.uninstall command. Requires the extension ID returned by install_extension or obtained from list_extensions.',
+  annotations: {
+    readOnlyHint: false,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -149,6 +155,9 @@ export const listExtensionsTool = {
     // privileged AddonManager API as a workaround for the currently missing
     // webExtension.getExtensions WebDriver BiDi command.
     'List installed Firefox extensions with UUIDs and background scripts. Requires MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1 env var.',
+  annotations: {
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {


### PR DESCRIPTION
All getters, listing APIs are set to `readOnlyHint: true`. All other tools are set to `readOnlyHint: false`. We could argue that things such as starting the profiler are normally readOnly, but it might still have an impact on the browser.