### PR TITLE
Bug 2057728 - Add saveTo and preview parameters to bulky-output tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,29 +162,46 @@ Both flags are required because the MCP uses both WebDriver Classic (`--marionet
 ## Tool overview
 
 - Pages: list/new/navigate/select/close
-- Snapshot/UID: take/resolve/clear
+- Snapshot/UID: take/resolve/clear (take supports optional `saveTo`)
 - Input: click/hover/fill/drag/upload/form fill
-- Network: list/get (ID‑first, filters, always‑on capture)
-- Console: list/clear
+- Network: list/get (ID‑first, filters, always‑on capture; both support optional `saveTo`)
+- Console: list/clear (list supports optional `saveTo`)
 - Screenshot: page/by uid (with optional `saveTo` for CLI environments)
-- Script: evaluate_script
+- Script: evaluate_script (with optional `saveTo` for bulky results)
 - Privileged Context: list/select privileged ("chrome") contexts, evaluate_privileged_script (requires `MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1`)
 - WebExtension: install_extension, uninstall_extension, list_extensions (list requires `MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1`)
 - Firefox Management: get_firefox_info, get_firefox_output, restart_firefox, set_firefox_prefs, get_firefox_prefs
 - Profiler: profiler_is_active, profiler_start (preset or explicit config), profiler_stop (saves profile to downloads directory)
 - Utilities: accept/dismiss dialog, history back/forward, set viewport
 
-### Screenshot optimization for Claude Code
+### Saving bulky output to disk
 
-When using screenshots in Claude Code CLI, the base64 image data can consume significant context.
-Use the `saveTo` parameter to save screenshots to disk instead:
+Large tool output can consume significant context in CLI clients like Claude Code. The
+`screenshot_page`, `screenshot_by_uid`, `take_snapshot`, `list_console_messages`,
+`list_network_requests`, `get_network_request`, `evaluate_script`, and
+`evaluate_privileged_script` tools accept an optional `saveTo` parameter that writes the
+result to a file instead of returning it inline. `saveTo` takes one of three forms:
+
+- a file path (absolute, or relative to the current working directory; parent directories are created)
+- an existing directory (a timestamped file is generated inside it)
+- `true` (a timestamped file is generated under `~/.firefox-devtools-mcp/output/`)
+
+The response returns the path and byte size. The saved file always holds the full,
+untruncated data: the inline size safeguards (console message caps, network header
+truncation, snapshot line caps) never apply to it.
+
+The text-producing tools (everything except the screenshots) also accept `preview`, a number
+of characters of the saved output to echo back inline as a short excerpt. Screenshots have no
+preview.
 
 ```
 screenshot_page({ saveTo: "/tmp/page.png" })
-screenshot_by_uid({ uid: "abc123", saveTo: "/tmp/element.png" })
+take_snapshot({ saveTo: true })
+list_network_requests({ urlContains: "api", saveTo: "/tmp/net.json" })
+evaluate_script({ function: "() => performance.getEntries()", saveTo: true, preview: 2000 })
 ```
 
-The file can then be viewed with Claude Code's `Read` tool without impacting context size.
+Saved files can then be viewed with Claude Code's `Read` tool without impacting context size.
 
 ## Local development
 

--- a/src/tools/console.ts
+++ b/src/tools/console.ts
@@ -9,6 +9,7 @@ import {
   TOKEN_LIMITS,
   truncateText,
 } from '../utils/response-helpers.js';
+import { saveOutput } from '../utils/save-output.js';
 import type { McpToolResponse } from '../types/common.js';
 
 export const listConsoleMessagesTool = {
@@ -46,6 +47,16 @@ export const listConsoleMessagesTool = {
         enum: ['text', 'json'],
         description: 'Output format (default: text)',
       },
+      saveTo: {
+        type: ['boolean', 'string'],
+        description:
+          'Save all matching messages to a file in full (no truncation or limit) instead of returning them inline. Pass a file path, an existing directory (generated file inside), or true (generated file under ~/.firefox-devtools-mcp/output/). Relative paths resolve against the current working directory.',
+      },
+      preview: {
+        type: 'number',
+        description:
+          'Number of characters of the saved output to return inline as a preview when saveTo is used. Omit for no preview.',
+      },
     },
   },
 };
@@ -64,6 +75,18 @@ export const clearConsoleMessagesTool = {
 
 const DEFAULT_LIMIT = 50;
 
+function formatMessageLine(msg: {
+  level: string;
+  text: string;
+  source?: string | undefined;
+  timestamp?: number | undefined;
+}): string {
+  const timestamp = msg.timestamp ? new Date(msg.timestamp).toISOString() : '';
+  const source = msg.source ? ` [${msg.source}]` : '';
+  const time = timestamp ? `[${timestamp}] ` : '';
+  return `${time}${msg.level.toUpperCase()}${source}: ${msg.text}`;
+}
+
 export async function handleListConsoleMessages(args: unknown): Promise<McpToolResponse> {
   try {
     const {
@@ -73,6 +96,8 @@ export async function handleListConsoleMessages(args: unknown): Promise<McpToolR
       textContains,
       source,
       format = 'text',
+      saveTo,
+      preview,
     } = (args as {
       level?: string;
       limit?: number;
@@ -80,6 +105,8 @@ export async function handleListConsoleMessages(args: unknown): Promise<McpToolR
       textContains?: string;
       source?: string;
       format?: 'text' | 'json';
+      saveTo?: boolean | string;
+      preview?: number;
     }) || {};
 
     const { getFirefox } = await import('../index.js');
@@ -105,6 +132,38 @@ export async function handleListConsoleMessages(args: unknown): Promise<McpToolR
 
     if (source) {
       messages = messages.filter((msg) => msg.source?.toLowerCase() === source.toLowerCase());
+    }
+
+    if (saveTo && messages.length > 0) {
+      const fileBody =
+        format === 'json'
+          ? JSON.stringify(
+              {
+                total: totalCount,
+                filtered: messages.length,
+                messages: messages.map((msg) => ({
+                  level: msg.level,
+                  text: msg.text,
+                  source: msg.source || null,
+                  timestamp: msg.timestamp || null,
+                })),
+              },
+              null,
+              2
+            )
+          : messages.map(formatMessageLine).join('\n');
+      const saved = await saveOutput(
+        fileBody,
+        saveTo === true ? undefined : saveTo,
+        'console-messages',
+        format === 'json' ? 'json' : 'txt'
+      );
+      let output = `Console messages (${messages.length} matching, ${totalCount} total) saved to: ${saved.path} (${(saved.bytes / 1024).toFixed(1)}KB)`;
+      if (preview !== undefined && preview > 0) {
+        const previewChars = Math.min(Math.max(preview, 50), TOKEN_LIMITS.MAX_RESPONSE_CHARS);
+        output += '\nPreview:\n' + truncateText(fileBody, previewChars);
+      }
+      return successResponse(output);
     }
 
     // Truncate individual message texts to prevent token overflow
@@ -207,11 +266,7 @@ export async function handleListConsoleMessages(args: unknown): Promise<McpToolR
     output += '\n';
 
     for (const msg of messages) {
-      const timestamp = msg.timestamp ? new Date(msg.timestamp).toISOString() : '';
-      const source = msg.source ? ` [${msg.source}]` : '';
-      const time = timestamp ? `[${timestamp}] ` : '';
-
-      output += `${time}${msg.level.toUpperCase()}${source}: ${msg.text}\n`;
+      output += `${formatMessageLine(msg)}\n`;
     }
 
     if (truncated) {

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -8,7 +8,10 @@ import {
   errorResponse,
   jsonResponse,
   truncateHeaders,
+  truncateText,
+  TOKEN_LIMITS,
 } from '../utils/response-helpers.js';
+import { saveOutput } from '../utils/save-output.js';
 import type { McpToolResponse } from '../types/common.js';
 
 // Tool definitions
@@ -72,6 +75,16 @@ export const listNetworkRequestsTool = {
         enum: ['text', 'json'],
         description: 'Output format (default: text)',
       },
+      saveTo: {
+        type: ['boolean', 'string'],
+        description:
+          'Save all matching requests with full untruncated headers to a file as JSON (ignores limit and detail) instead of returning them inline. Pass a file path, an existing directory (generated file inside), or true (generated file under ~/.firefox-devtools-mcp/output/). Relative paths resolve against the current working directory.',
+      },
+      preview: {
+        type: 'number',
+        description:
+          'Number of characters of the saved output to return inline as a preview when saveTo is used. Omit for no preview.',
+      },
     },
   },
 };
@@ -98,6 +111,16 @@ export const getNetworkRequestTool = {
         enum: ['text', 'json'],
         description: 'Output format (default: text)',
       },
+      saveTo: {
+        type: ['boolean', 'string'],
+        description:
+          'Save the request details with full untruncated headers to a file as JSON instead of returning them inline. Pass a file path, an existing directory (generated file inside), or true (generated file under ~/.firefox-devtools-mcp/output/). Relative paths resolve against the current working directory.',
+      },
+      preview: {
+        type: 'number',
+        description:
+          'Number of characters of the saved output to return inline as a preview when saveTo is used. Omit for no preview.',
+      },
     },
   },
 };
@@ -118,6 +141,8 @@ export async function handleListNetworkRequests(args: unknown): Promise<McpToolR
       sortBy = 'timestamp',
       detail = 'summary',
       format = 'text',
+      saveTo,
+      preview,
     } = (args as {
       limit?: number;
       sinceMs?: number;
@@ -131,6 +156,8 @@ export async function handleListNetworkRequests(args: unknown): Promise<McpToolR
       sortBy?: 'timestamp' | 'duration' | 'status';
       detail?: 'summary' | 'min' | 'full';
       format?: 'text' | 'json';
+      saveTo?: boolean | string;
+      preview?: number;
     }) || {};
 
     const { getFirefox } = await import('../index.js');
@@ -183,6 +210,40 @@ export async function handleListNetworkRequests(args: unknown): Promise<McpToolR
       requests.sort((a, b) => (b.timings?.duration || 0) - (a.timings?.duration || 0));
     } else if (sortBy === 'status') {
       requests.sort((a, b) => (a.status || 0) - (b.status || 0));
+    }
+
+    if (saveTo && requests.length > 0) {
+      const fileBody = JSON.stringify(
+        {
+          total: requests.length,
+          requests: requests.map((req) => ({
+            id: req.id,
+            url: req.url,
+            method: req.method,
+            status: req.status ?? null,
+            statusText: req.statusText ?? null,
+            resourceType: req.resourceType ?? null,
+            isXHR: req.isXHR ?? false,
+            timestamp: req.timestamp ?? null,
+            timings: req.timings ?? null,
+            requestHeaders: req.requestHeaders ?? null,
+            responseHeaders: req.responseHeaders ?? null,
+          })),
+        },
+        null,
+        2
+      );
+      const saved = await saveOutput(
+        fileBody,
+        saveTo === true ? undefined : saveTo,
+        'network-requests'
+      );
+      let output = `${requests.length} network requests saved to: ${saved.path} (${(saved.bytes / 1024).toFixed(1)}KB)`;
+      if (preview !== undefined && preview > 0) {
+        const previewChars = Math.min(Math.max(preview, 50), TOKEN_LIMITS.MAX_RESPONSE_CHARS);
+        output += '\nPreview:\n```json\n' + truncateText(fileBody, previewChars) + '\n```';
+      }
+      return successResponse(output);
     }
 
     // Apply limit
@@ -284,11 +345,13 @@ export async function handleListNetworkRequests(args: unknown): Promise<McpToolR
 
 export async function handleGetNetworkRequest(args: unknown): Promise<McpToolResponse> {
   try {
-    const {
-      id,
-      url,
-      format = 'text',
-    } = args as { id?: string; url?: string; format?: 'text' | 'json' };
+    const { id, url, format, saveTo, preview } = args as {
+      id?: string;
+      url?: string;
+      format?: 'text' | 'json';
+      saveTo?: boolean | string;
+      preview?: number;
+    };
 
     if (!id && !url) {
       return errorResponse('id or url required');
@@ -326,8 +389,7 @@ export async function handleGetNetworkRequest(args: unknown): Promise<McpToolRes
       return errorResponse('Request not found');
     }
 
-    // Format request details - apply header truncation to prevent token overflow
-    const details = {
+    const fullDetails = {
       id: request.id,
       url: request.url,
       method: request.method,
@@ -337,6 +399,28 @@ export async function handleGetNetworkRequest(args: unknown): Promise<McpToolRes
       isXHR: request.isXHR ?? false,
       timestamp: request.timestamp ?? null,
       timings: request.timings ?? null,
+      requestHeaders: request.requestHeaders ?? null,
+      responseHeaders: request.responseHeaders ?? null,
+    };
+
+    if (saveTo) {
+      const fileBody = JSON.stringify(fullDetails, null, 2);
+      const saved = await saveOutput(
+        fileBody,
+        saveTo === true ? undefined : saveTo,
+        'network-request'
+      );
+      let output = `Request ${request.id} saved to: ${saved.path} (${(saved.bytes / 1024).toFixed(1)}KB)`;
+      if (preview !== undefined && preview > 0) {
+        const previewChars = Math.min(Math.max(preview, 50), TOKEN_LIMITS.MAX_RESPONSE_CHARS);
+        output += '\nPreview:\n```json\n' + truncateText(fileBody, previewChars) + '\n```';
+      }
+      return successResponse(output);
+    }
+
+    // Apply header truncation to prevent token overflow
+    const details = {
+      ...fullDetails,
       requestHeaders: truncateHeaders(request.requestHeaders),
       responseHeaders: truncateHeaders(request.responseHeaders),
     };

--- a/src/tools/privileged-context.ts
+++ b/src/tools/privileged-context.ts
@@ -3,9 +3,15 @@
  * Requires MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1
  */
 
-import { successResponse, errorResponse } from '../utils/response-helpers.js';
+import {
+  successResponse,
+  errorResponse,
+  truncateText,
+  TOKEN_LIMITS,
+} from '../utils/response-helpers.js';
 import { validateFunction } from '../utils/js-validation.js';
 import { remoteValueToNative } from '../utils/remote-value.js';
+import { saveOutput } from '../utils/save-output.js';
 import type { McpToolResponse } from '../types/common.js';
 
 export const listPrivilegedContextsTool = {
@@ -53,6 +59,16 @@ export const evaluatePrivilegedScriptTool = {
       function: {
         type: 'string',
         description: 'JS function string, e.g. () => Services.prefs.getBoolPref("foo")',
+      },
+      saveTo: {
+        type: ['boolean', 'string'],
+        description:
+          'Save the result to a file as JSON instead of returning it inline. Pass a file path, an existing directory (generated file inside), or true (generated file under ~/.firefox-devtools-mcp/output/). Relative paths resolve against the current working directory.',
+      },
+      preview: {
+        type: 'number',
+        description:
+          'Number of characters of the saved result to return inline as a preview when saveTo is used. Omit for no preview.',
       },
     },
     required: ['function'],
@@ -141,7 +157,15 @@ const EvaluateResultType = {
 
 export async function handleEvaluatePrivilegedScript(args: unknown): Promise<McpToolResponse> {
   try {
-    const { function: fnString } = args as { function: string };
+    const {
+      function: fnString,
+      saveTo,
+      preview,
+    } = args as {
+      function: string;
+      saveTo?: boolean | string;
+      preview?: number;
+    };
 
     validateFunction(fnString);
 
@@ -156,11 +180,26 @@ export async function handleEvaluatePrivilegedScript(args: unknown): Promise<Mcp
     });
 
     if (result.type === EvaluateResultType.Success) {
-      let output = 'Script ran in chrome context and returned:\n';
-      output += '```json\n';
-      output += JSON.stringify(remoteValueToNative(result.result), null, 2);
-      output += '\n```';
-      return successResponse(output);
+      // JSON.stringify returns undefined for an undefined script result
+      const json = JSON.stringify(remoteValueToNative(result.result), null, 2) ?? 'undefined';
+
+      if (saveTo) {
+        const saved = await saveOutput(
+          json,
+          saveTo === true ? undefined : saveTo,
+          'evaluate-privileged'
+        );
+        let output = `Script ran in chrome context. Result saved to: ${saved.path} (${(saved.bytes / 1024).toFixed(1)}KB)`;
+        if (preview !== undefined && preview > 0) {
+          const previewChars = Math.min(Math.max(preview, 50), TOKEN_LIMITS.MAX_RESPONSE_CHARS);
+          output += '\nPreview:\n```json\n' + truncateText(json, previewChars) + '\n```';
+        }
+        return successResponse(output);
+      }
+
+      return successResponse(
+        'Script ran in chrome context and returned:\n```json\n' + json + '\n```'
+      );
     } else if (result.type === EvaluateResultType.Exception) {
       const exceptionDetails = result.exceptionDetails;
       return errorResponse(

--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -2,16 +2,15 @@
  * Screenshot tools for visual capture
  */
 
-import { writeFile, mkdir } from 'node:fs/promises';
-import { resolve, dirname } from 'node:path';
 import { successResponse, errorResponse } from '../utils/response-helpers.js';
 import { handleUidError } from '../utils/uid-helpers.js';
+import { saveOutput } from '../utils/save-output.js';
 import type { McpToolResponse } from '../types/common.js';
 
 const SAVE_TO_SCHEMA = {
-  type: 'string',
+  type: ['boolean', 'string'],
   description:
-    'Optional file path to save the screenshot to instead of returning it as image data in the response.',
+    'Save the screenshot to a file instead of returning it as image data in the response. Pass a file path, an existing directory (generated file inside), or true (generated file under ~/.firefox-devtools-mcp/output/). Relative paths resolve against the current working directory.',
 } as const;
 
 // Tool definitions
@@ -51,14 +50,12 @@ export const screenshotByUidTool = {
 /**
  * Save screenshot to file and return text response with path.
  */
-async function saveScreenshot(base64Png: string, saveTo: string): Promise<McpToolResponse> {
+async function saveScreenshot(base64Png: string, saveTo: true | string): Promise<McpToolResponse> {
   const buffer = Buffer.from(base64Png, 'base64');
-  const resolvedPath = resolve(saveTo);
-  await mkdir(dirname(resolvedPath), { recursive: true });
-  await writeFile(resolvedPath, buffer);
+  const saved = await saveOutput(buffer, saveTo === true ? undefined : saveTo, 'screenshot', 'png');
 
   return successResponse(
-    `Screenshot saved to: ${resolvedPath} (${(buffer.length / 1024).toFixed(1)}KB)`
+    `Screenshot saved to: ${saved.path} (${(saved.bytes / 1024).toFixed(1)}KB)`
   );
 }
 
@@ -80,7 +77,7 @@ function imageResponse(base64Png: string): McpToolResponse {
 // Handlers
 export async function handleScreenshotPage(args: unknown): Promise<McpToolResponse> {
   try {
-    const { saveTo } = (args ?? {}) as { saveTo?: string };
+    const { saveTo } = (args ?? {}) as { saveTo?: boolean | string };
 
     const { getFirefox } = await import('../index.js');
     const firefox = await getFirefox();
@@ -103,7 +100,7 @@ export async function handleScreenshotPage(args: unknown): Promise<McpToolRespon
 
 export async function handleScreenshotByUid(args: unknown): Promise<McpToolResponse> {
   try {
-    const { uid, saveTo } = args as { uid: string; saveTo?: string };
+    const { uid, saveTo } = args as { uid: string; saveTo?: boolean | string };
 
     if (!uid || typeof uid !== 'string') {
       throw new Error('uid required');

--- a/src/tools/script.ts
+++ b/src/tools/script.ts
@@ -2,9 +2,15 @@
  * JavaScript evaluation tool
  */
 
-import { successResponse, errorResponse } from '../utils/response-helpers.js';
+import {
+  successResponse,
+  errorResponse,
+  truncateText,
+  TOKEN_LIMITS,
+} from '../utils/response-helpers.js';
 import { remoteValueToNative } from '../utils/remote-value.js';
 import { validateFunction } from '../utils/js-validation.js';
+import { saveOutput } from '../utils/save-output.js';
 import type { McpToolResponse } from '../types/common.js';
 
 export const evaluateScriptTool = {
@@ -38,6 +44,16 @@ export const evaluateScriptTool = {
         type: 'number',
         description: 'Timeout in ms (default: 5000)',
       },
+      saveTo: {
+        type: ['boolean', 'string'],
+        description:
+          'Save the result to a file as JSON instead of returning it inline. Pass a file path, an existing directory (generated file inside), or true (generated file under ~/.firefox-devtools-mcp/output/). Relative paths resolve against the current working directory.',
+      },
+      preview: {
+        type: 'number',
+        description:
+          'Number of characters of the saved result to return inline as a preview when saveTo is used. Omit for no preview.',
+      },
     },
     required: ['function'],
   },
@@ -59,10 +75,14 @@ export async function handleEvaluateScript(args: unknown): Promise<McpToolRespon
       function: fnString,
       args: fnArgs,
       timeout,
+      saveTo,
+      preview,
     } = args as {
       function: string;
       args?: Array<{ uid: string }>;
       timeout?: number;
+      saveTo?: boolean | string;
+      preview?: number;
     };
 
     // Validate function
@@ -125,13 +145,25 @@ export async function handleEvaluateScript(args: unknown): Promise<McpToolRespon
         )
       );
     } else if (result.type === EvaluateResultType.Success) {
-      // Format output
-      let output = 'Script ran on page and returned:\n';
-      output += '```json\n';
-      output += JSON.stringify(remoteValueToNative(result.result), null, 2);
-      output += '\n```';
+      // JSON.stringify returns undefined for an undefined script result
+      const json = JSON.stringify(remoteValueToNative(result.result), null, 2) ?? 'undefined';
 
-      return successResponse(output);
+      if (saveTo) {
+        const saved = await saveOutput(
+          json,
+          saveTo === true ? undefined : saveTo,
+          'evaluate-script'
+        );
+        let output = `Script ran on page. Result saved to: ${saved.path} (${(saved.bytes / 1024).toFixed(1)}KB)`;
+        if (preview !== undefined && preview > 0) {
+          // Floor keeps truncateText's suffix from dominating tiny budgets.
+          const previewChars = Math.min(Math.max(preview, 50), TOKEN_LIMITS.MAX_RESPONSE_CHARS);
+          output += '\nPreview:\n```json\n' + truncateText(json, previewChars) + '\n```';
+        }
+        return successResponse(output);
+      }
+
+      return successResponse('Script ran on page and returned:\n```json\n' + json + '\n```');
     } else if (result.type === EvaluateResultType.Exception) {
       const exceptionDetails = result.exceptionDetails;
       return errorResponse(

--- a/src/tools/snapshot.ts
+++ b/src/tools/snapshot.ts
@@ -2,8 +2,14 @@
  * Snapshot tools for DOM structure capture with UID mapping
  */
 
-import { successResponse, errorResponse, TOKEN_LIMITS } from '../utils/response-helpers.js';
+import {
+  successResponse,
+  errorResponse,
+  TOKEN_LIMITS,
+  truncateText,
+} from '../utils/response-helpers.js';
 import { handleUidError } from '../utils/uid-helpers.js';
+import { saveOutput } from '../utils/save-output.js';
 import type { McpToolResponse } from '../types/common.js';
 
 const DEFAULT_SNAPSHOT_LINES = 100;
@@ -42,6 +48,16 @@ export const takeSnapshotTool = {
       selector: {
         type: 'string',
         description: 'CSS selector to scope snapshot to specific element (e.g., "#app")',
+      },
+      saveTo: {
+        type: ['boolean', 'string'],
+        description:
+          'Save the complete snapshot text to a file (ignores maxLines) instead of returning it inline. Pass a file path, an existing directory (generated file inside), or true (generated file under ~/.firefox-devtools-mcp/output/). Relative paths resolve against the current working directory.',
+      },
+      preview: {
+        type: 'number',
+        description:
+          'Number of characters of the saved output to return inline as a preview when saveTo is used. Omit for no preview.',
       },
     },
   },
@@ -87,6 +103,8 @@ export async function handleTakeSnapshot(args: unknown): Promise<McpToolResponse
       maxDepth,
       includeAll = false,
       selector,
+      saveTo,
+      preview,
     } = (args as {
       maxLines?: number;
       includeAttributes?: boolean;
@@ -94,6 +112,8 @@ export async function handleTakeSnapshot(args: unknown): Promise<McpToolResponse
       maxDepth?: number;
       includeAll?: boolean;
       selector?: string;
+      saveTo?: boolean | string;
+      preview?: number;
     }) || {};
 
     // Apply hard cap on maxLines to prevent token overflow
@@ -125,6 +145,24 @@ export async function handleTakeSnapshot(args: unknown): Promise<McpToolResponse
       options.maxDepth = maxDepth;
     }
     const formattedText = formatSnapshotTree(snapshot.json.root, 0, options);
+
+    if (saveTo) {
+      const saved = await saveOutput(
+        formattedText,
+        saveTo === true ? undefined : saveTo,
+        'snapshot',
+        'txt'
+      );
+      let output = `Snapshot (id=${snapshot.json.snapshotId}) saved to: ${saved.path} (${(saved.bytes / 1024).toFixed(1)}KB)`;
+      if (snapshot.json.truncated) {
+        output += ' [DOM truncated]';
+      }
+      if (preview !== undefined && preview > 0) {
+        const previewChars = Math.min(Math.max(preview, 50), TOKEN_LIMITS.MAX_RESPONSE_CHARS);
+        output += '\nPreview:\n' + truncateText(formattedText, previewChars);
+      }
+      return successResponse(output);
+    }
 
     // Get snapshot text (truncated if needed)
     const lines = formattedText.split('\n');

--- a/src/utils/save-output.ts
+++ b/src/utils/save-output.ts
@@ -1,0 +1,67 @@
+/**
+ * Helper for saving bulky tool output to disk instead of returning it inline.
+ */
+
+import { mkdir, rename, stat, unlink, writeFile } from 'node:fs/promises';
+import { randomBytes } from 'node:crypto';
+import { homedir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+
+export interface SavedOutput {
+  path: string;
+  bytes: number;
+}
+
+function generatedName(baseName: string, extension: string): string {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  return `${baseName}-${timestamp}.${extension}`;
+}
+
+async function isDirectory(path: string): Promise<boolean> {
+  try {
+    return (await stat(path)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Write content to saveTo: a file path (absolute or CWD-relative, parent
+ * directories created as needed), or an existing directory (a generated file
+ * named after baseName is placed inside). When saveTo is empty, the generated
+ * file goes to ~/.firefox-devtools-mcp/output/.
+ */
+export async function saveOutput(
+  content: string | Buffer,
+  saveTo: string | undefined,
+  baseName: string,
+  extension = 'json'
+): Promise<SavedOutput> {
+  let resolvedPath: string;
+  if (saveTo) {
+    resolvedPath = resolve(saveTo);
+    if (await isDirectory(resolvedPath)) {
+      resolvedPath = join(resolvedPath, generatedName(baseName, extension));
+    }
+  } else {
+    resolvedPath = join(
+      homedir(),
+      '.firefox-devtools-mcp',
+      'output',
+      generatedName(baseName, extension)
+    );
+  }
+  await mkdir(dirname(resolvedPath), { recursive: true });
+
+  // Write via a sibling temp file and rename so a failed write never leaves a partial file.
+  const tmpPath = `${resolvedPath}.${randomBytes(6).toString('hex')}.tmp`;
+  try {
+    await writeFile(tmpPath, content);
+    await rename(tmpPath, resolvedPath);
+  } catch (error) {
+    await unlink(tmpPath).catch(() => undefined);
+    throw error;
+  }
+
+  return { path: resolvedPath, bytes: Buffer.byteLength(content) };
+}

--- a/tests/tools/console.test.ts
+++ b/tests/tools/console.test.ts
@@ -2,7 +2,10 @@
  * Unit tests for console tools
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { listConsoleMessagesTool, clearConsoleMessagesTool } from '../../src/tools/console.js';
 
 describe('Console Tools', () => {
@@ -53,6 +56,95 @@ describe('Console Tools', () => {
       expect(properties?.format).toBeDefined();
       expect(properties?.format.enum).toContain('text');
       expect(properties?.format.enum).toContain('json');
+    });
+
+    it('should have optional saveTo parameter of type boolean|string', () => {
+      const { properties } = listConsoleMessagesTool.inputSchema;
+      expect(properties?.saveTo).toBeDefined();
+      expect(properties?.saveTo.type).toEqual(['boolean', 'string']);
+    });
+
+    it('should have optional numeric preview parameter', () => {
+      const { properties } = listConsoleMessagesTool.inputSchema;
+      expect(properties?.preview).toBeDefined();
+      expect(properties?.preview.type).toBe('number');
+    });
+
+    it('should not mark saveTo or preview as required', () => {
+      expect(
+        (listConsoleMessagesTool.inputSchema as { required?: string[] }).required
+      ).toBeUndefined();
+    });
+  });
+
+  describe('Handler: saveTo behavior', () => {
+    const LONG_TEXT = 'y'.repeat(3000);
+    const MESSAGES = [
+      { level: 'info', text: 'first message', source: 'console-api', timestamp: 1700000000000 },
+      { level: 'error', text: LONG_TEXT, source: 'javascript', timestamp: 1700000001000 },
+      { level: 'warn', text: 'third message', source: 'console-api', timestamp: 1700000002000 },
+    ];
+    let tempDir: string;
+
+    beforeEach(() => {
+      tempDir = join(tmpdir(), `console-test-${Date.now()}`);
+
+      vi.doMock('../../src/index.js', () => ({
+        getFirefox: vi.fn().mockResolvedValue({
+          getConsoleMessages: vi.fn().mockResolvedValue(MESSAGES),
+        }),
+      }));
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+      if (existsSync(tempDir)) {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should save all matching messages in full without truncation', async () => {
+      const { handleListConsoleMessages } = await import('../../src/tools/console.js');
+      const filePath = join(tempDir, 'console.txt');
+      const result = await handleListConsoleMessages({ saveTo: filePath });
+
+      expect(result.isError).toBeUndefined();
+      const text = (result.content[0] as { type: 'text'; text: string }).text;
+      expect(text).toContain('saved to:');
+      const fileContent = readFileSync(filePath, 'utf8');
+      expect(fileContent).toContain(LONG_TEXT);
+      expect(fileContent).not.toContain('...[truncated]');
+    });
+
+    it('should include a preview when preview is given', async () => {
+      const { handleListConsoleMessages } = await import('../../src/tools/console.js');
+      const result = await handleListConsoleMessages({
+        saveTo: join(tempDir, 'console.txt'),
+        preview: 100,
+      });
+
+      const text = (result.content[0] as { type: 'text'; text: string }).text;
+      expect(text).toContain('Preview:');
+    });
+
+    it('should write JSON with all messages when format is json', async () => {
+      const { handleListConsoleMessages } = await import('../../src/tools/console.js');
+      const filePath = join(tempDir, 'console.json');
+      await handleListConsoleMessages({ saveTo: filePath, format: 'json' });
+
+      const parsed = JSON.parse(readFileSync(filePath, 'utf8'));
+      expect(parsed.messages).toHaveLength(3);
+      expect(parsed.total).toBe(3);
+      expect(parsed.filtered).toBe(3);
+    });
+
+    it('should ignore limit when saving to a file', async () => {
+      const { handleListConsoleMessages } = await import('../../src/tools/console.js');
+      const filePath = join(tempDir, 'console.json');
+      await handleListConsoleMessages({ saveTo: filePath, format: 'json', limit: 1 });
+
+      const parsed = JSON.parse(readFileSync(filePath, 'utf8'));
+      expect(parsed.messages).toHaveLength(3);
     });
   });
 });

--- a/tests/tools/network.test.ts
+++ b/tests/tools/network.test.ts
@@ -2,7 +2,10 @@
  * Unit tests for network tools
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { listNetworkRequestsTool, getNetworkRequestTool } from '../../src/tools/network.js';
 
 describe('Network Tools', () => {
@@ -54,6 +57,116 @@ describe('Network Tools', () => {
       expect(properties?.format).toBeDefined();
       expect(properties?.format.enum).toContain('text');
       expect(properties?.format.enum).toContain('json');
+    });
+
+    it('listNetworkRequestsTool should have optional saveTo and preview', () => {
+      const { properties } = listNetworkRequestsTool.inputSchema;
+      expect(properties?.saveTo).toBeDefined();
+      expect(properties?.saveTo.type).toEqual(['boolean', 'string']);
+      expect(properties?.preview.type).toBe('number');
+    });
+
+    it('getNetworkRequestTool should have optional saveTo and preview', () => {
+      const { properties } = getNetworkRequestTool.inputSchema;
+      expect(properties?.saveTo).toBeDefined();
+      expect(properties?.saveTo.type).toEqual(['boolean', 'string']);
+      expect(properties?.preview.type).toBe('number');
+    });
+
+    it('should not mark saveTo or preview as required', () => {
+      expect(
+        (listNetworkRequestsTool.inputSchema as { required?: string[] }).required
+      ).toBeUndefined();
+      expect(
+        (getNetworkRequestTool.inputSchema as { required?: string[] }).required
+      ).toBeUndefined();
+    });
+  });
+
+  describe('Handler: saveTo behavior', () => {
+    const LONG_HEADER = 'z'.repeat(600);
+    const REQUESTS = [
+      {
+        id: 'r1',
+        url: 'https://example.test/one',
+        method: 'GET',
+        status: 200,
+        statusText: 'OK',
+        resourceType: 'document',
+        isXHR: false,
+        timestamp: 1700000000000,
+        timings: { duration: 12 },
+        requestHeaders: { 'x-big': LONG_HEADER },
+        responseHeaders: { 'content-type': 'text/html' },
+      },
+      {
+        id: 'r2',
+        url: 'https://example.test/two',
+        method: 'POST',
+        status: 201,
+        statusText: 'Created',
+        resourceType: 'xhr',
+        isXHR: true,
+        timestamp: 1700000001000,
+        timings: { duration: 34 },
+        requestHeaders: { 'x-small': 'ok' },
+        responseHeaders: {},
+      },
+    ];
+    let tempDir: string;
+
+    beforeEach(() => {
+      tempDir = join(tmpdir(), `network-test-${Date.now()}`);
+
+      vi.doMock('../../src/index.js', () => ({
+        getFirefox: vi.fn().mockResolvedValue({
+          getNetworkRequests: vi.fn().mockResolvedValue(REQUESTS),
+        }),
+      }));
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+      if (existsSync(tempDir)) {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should save all requests with full untruncated headers', async () => {
+      const { handleListNetworkRequests } = await import('../../src/tools/network.js');
+      const filePath = join(tempDir, 'network.json');
+      const result = await handleListNetworkRequests({ saveTo: filePath });
+
+      expect(result.isError).toBeUndefined();
+      const text = (result.content[0] as { type: 'text'; text: string }).text;
+      expect(text).toContain('saved to:');
+      const raw = readFileSync(filePath, 'utf8');
+      expect(raw).toContain(LONG_HEADER);
+      expect(raw).not.toContain('...[truncated]');
+      expect(raw).not.toContain('__truncated__');
+    });
+
+    it('should ignore limit when saving to a file', async () => {
+      const { handleListNetworkRequests } = await import('../../src/tools/network.js');
+      const filePath = join(tempDir, 'network.json');
+      await handleListNetworkRequests({ saveTo: filePath, limit: 1 });
+
+      const parsed = JSON.parse(readFileSync(filePath, 'utf8'));
+      expect(parsed.requests).toHaveLength(2);
+      expect(parsed.total).toBe(2);
+    });
+
+    it('should save a single request with raw headers by id', async () => {
+      const { handleGetNetworkRequest } = await import('../../src/tools/network.js');
+      const filePath = join(tempDir, 'request.json');
+      const result = await handleGetNetworkRequest({ id: 'r1', saveTo: filePath });
+
+      expect(result.isError).toBeUndefined();
+      const text = (result.content[0] as { type: 'text'; text: string }).text;
+      expect(text).toContain('Request r1 saved to:');
+      const raw = readFileSync(filePath, 'utf8');
+      expect(raw).toContain(LONG_HEADER);
+      expect(raw).not.toContain('...[truncated]');
     });
   });
 });

--- a/tests/tools/privileged-context.test.ts
+++ b/tests/tools/privileged-context.test.ts
@@ -20,6 +20,20 @@ describe('Privileged Context Tool Definitions', () => {
     it('should require function parameter', () => {
       expect(evaluatePrivilegedScriptTool.inputSchema.required).toContain('function');
     });
+
+    it('should have optional saveTo parameter of type boolean|string', () => {
+      const { properties, required } = evaluatePrivilegedScriptTool.inputSchema;
+      expect(properties?.saveTo).toBeDefined();
+      expect(properties?.saveTo.type).toEqual(['boolean', 'string']);
+      expect(required).not.toContain('saveTo');
+    });
+
+    it('should have optional numeric preview parameter', () => {
+      const { properties, required } = evaluatePrivilegedScriptTool.inputSchema;
+      expect(properties?.preview).toBeDefined();
+      expect(properties?.preview.type).toBe('number');
+      expect(required).not.toContain('preview');
+    });
   });
 });
 

--- a/tests/tools/screenshot.test.ts
+++ b/tests/tools/screenshot.test.ts
@@ -8,6 +8,13 @@ import { existsSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
+const MOCK_HOME = join(tmpdir(), 'screenshot-test-home');
+
+vi.mock('node:os', async (importOriginal) => {
+  const os = await importOriginal<typeof import('node:os')>();
+  return { ...os, homedir: () => MOCK_HOME };
+});
+
 describe('Screenshot Tools', () => {
   describe('Tool Definitions', () => {
     it('should have correct tool names', () => {
@@ -32,7 +39,7 @@ describe('Screenshot Tools', () => {
       const { properties } = screenshotPageTool.inputSchema;
       expect(properties).toBeDefined();
       expect(properties?.saveTo).toBeDefined();
-      expect(properties?.saveTo?.type).toBe('string');
+      expect(properties?.saveTo?.type).toEqual(['boolean', 'string']);
     });
 
     it('screenshotByUidTool should require uid and have optional saveTo', () => {
@@ -40,7 +47,7 @@ describe('Screenshot Tools', () => {
       expect(properties).toBeDefined();
       expect(properties?.uid).toBeDefined();
       expect(properties?.saveTo).toBeDefined();
-      expect(properties?.saveTo?.type).toBe('string');
+      expect(properties?.saveTo?.type).toEqual(['boolean', 'string']);
       expect(required).toContain('uid');
       expect(required).not.toContain('saveTo');
     });
@@ -63,8 +70,10 @@ describe('Screenshot Tools', () => {
 
     afterEach(() => {
       vi.restoreAllMocks();
-      if (existsSync(tempDir)) {
-        rmSync(tempDir, { recursive: true, force: true });
+      for (const dir of [tempDir, MOCK_HOME]) {
+        if (existsSync(dir)) {
+          rmSync(dir, { recursive: true, force: true });
+        }
       }
     });
 
@@ -139,6 +148,17 @@ describe('Screenshot Tools', () => {
       expect(result.isError).toBeUndefined();
       expect((result.content[0] as { type: 'text'; text: string }).text).toContain(relativePath);
       expect(existsSync(relativePath)).toBe(true);
+    });
+
+    it('should save to a generated file in the default output dir when saveTo is true', async () => {
+      const { handleScreenshotPage } = await import('../../src/tools/screenshot.js');
+      const result = await handleScreenshotPage({ saveTo: true });
+
+      expect(result.isError).toBeUndefined();
+      const text = (result.content[0] as { type: 'text'; text: string }).text;
+      expect(text).toContain('Screenshot saved to:');
+      expect(text).toContain(join(MOCK_HOME, '.firefox-devtools-mcp', 'output'));
+      expect(text).toContain('screenshot-');
     });
   });
 });

--- a/tests/tools/script.test.ts
+++ b/tests/tools/script.test.ts
@@ -2,8 +2,18 @@
  * Unit tests for script tools
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { evaluateScriptTool } from '../../src/tools/script.js';
+
+const MOCK_HOME = join(tmpdir(), 'script-test-home');
+
+vi.mock('node:os', async (importOriginal) => {
+  const os = await importOriginal<typeof import('node:os')>();
+  return { ...os, homedir: () => MOCK_HOME };
+});
 
 describe('Script Tools', () => {
   describe('Tool Definitions', () => {
@@ -39,6 +49,131 @@ describe('Script Tools', () => {
       const { properties } = evaluateScriptTool.inputSchema;
       expect(properties?.timeout).toBeDefined();
       expect(properties?.timeout.type).toBe('number');
+    });
+
+    it('should have optional saveTo parameter', () => {
+      const { properties, required } = evaluateScriptTool.inputSchema;
+      expect(properties?.saveTo).toBeDefined();
+      expect(properties?.saveTo.type).toEqual(['boolean', 'string']);
+      expect(required).not.toContain('saveTo');
+    });
+
+    it('should have optional preview parameter', () => {
+      const { properties, required } = evaluateScriptTool.inputSchema;
+      expect(properties?.preview).toBeDefined();
+      expect(properties?.preview.type).toBe('number');
+      expect(required).not.toContain('preview');
+    });
+  });
+
+  describe('Handler: saveTo behavior', () => {
+    const RESULT_VALUE = 'x'.repeat(5_000);
+    let tempDir: string;
+
+    beforeEach(() => {
+      tempDir = join(tmpdir(), `script-test-${Date.now()}`);
+
+      vi.doMock('../../src/index.js', () => ({
+        getFirefox: vi.fn().mockResolvedValue({
+          getCurrentContextId: vi.fn().mockReturnValue('ctx-1'),
+          sendBiDiCommand: vi.fn().mockResolvedValue({
+            type: 'success',
+            result: { type: 'string', value: RESULT_VALUE },
+          }),
+        }),
+      }));
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+      for (const dir of [tempDir, MOCK_HOME]) {
+        if (existsSync(dir)) {
+          rmSync(dir, { recursive: true, force: true });
+        }
+      }
+    });
+
+    it('should save result to file and return the path without a preview by default', async () => {
+      const { handleEvaluateScript } = await import('../../src/tools/script.js');
+      const filePath = join(tempDir, 'result.json');
+      const result = await handleEvaluateScript({ function: '() => 1', saveTo: filePath });
+
+      expect(result.isError).toBeUndefined();
+      const text = (result.content[0] as { type: 'text'; text: string }).text;
+      expect(text).toContain('Result saved to:');
+      expect(text).toContain('KB)');
+      expect(text).not.toContain('Preview:');
+      expect(existsSync(filePath)).toBe(true);
+      expect(JSON.parse(readFileSync(filePath, 'utf8'))).toBe(RESULT_VALUE);
+    });
+
+    it('should include a truncated preview when preview is given', async () => {
+      const { handleEvaluateScript } = await import('../../src/tools/script.js');
+      const filePath = join(tempDir, 'result.json');
+      const result = await handleEvaluateScript({
+        function: '() => 1',
+        saveTo: filePath,
+        preview: 100,
+      });
+
+      expect(result.isError).toBeUndefined();
+      const text = (result.content[0] as { type: 'text'; text: string }).text;
+      expect(text).toContain('Preview:');
+      expect(text).toContain('[... truncated');
+    });
+
+    it('should treat non-positive preview as no preview', async () => {
+      const { handleEvaluateScript } = await import('../../src/tools/script.js');
+      const filePath = join(tempDir, 'result.json');
+      const result = await handleEvaluateScript({
+        function: '() => 1',
+        saveTo: filePath,
+        preview: -1,
+      });
+
+      expect(result.isError).toBeUndefined();
+      const text = (result.content[0] as { type: 'text'; text: string }).text;
+      expect(text).not.toContain('Preview:');
+    });
+
+    it('should save the string "undefined" when the script returns undefined', async () => {
+      vi.resetModules();
+      vi.doMock('../../src/index.js', () => ({
+        getFirefox: vi.fn().mockResolvedValue({
+          getCurrentContextId: vi.fn().mockReturnValue('ctx-1'),
+          sendBiDiCommand: vi.fn().mockResolvedValue({
+            type: 'success',
+            result: { type: 'undefined' },
+          }),
+        }),
+      }));
+      const { handleEvaluateScript } = await import('../../src/tools/script.js');
+      const filePath = join(tempDir, 'undef.json');
+      const result = await handleEvaluateScript({ function: '() => undefined', saveTo: filePath });
+
+      expect(result.isError).toBeUndefined();
+      expect(readFileSync(filePath, 'utf8')).toBe('undefined');
+    });
+
+    it('should save to a generated file in the default output dir when saveTo is true', async () => {
+      const { handleEvaluateScript } = await import('../../src/tools/script.js');
+      const result = await handleEvaluateScript({ function: '() => 1', saveTo: true });
+
+      expect(result.isError).toBeUndefined();
+      const text = (result.content[0] as { type: 'text'; text: string }).text;
+      expect(text).toContain('Result saved to:');
+      expect(text).toContain(join(MOCK_HOME, '.firefox-devtools-mcp', 'output'));
+      expect(text).toContain('evaluate-script-');
+    });
+
+    it('should return result inline when saveTo is not provided', async () => {
+      const { handleEvaluateScript } = await import('../../src/tools/script.js');
+      const result = await handleEvaluateScript({ function: '() => 1' });
+
+      expect(result.isError).toBeUndefined();
+      const text = (result.content[0] as { type: 'text'; text: string }).text;
+      expect(text).toContain('Script ran on page and returned:');
+      expect(text).toContain(RESULT_VALUE);
     });
   });
 });

--- a/tests/tools/snapshot.test.ts
+++ b/tests/tools/snapshot.test.ts
@@ -2,7 +2,10 @@
  * Unit tests for snapshot tools
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import {
   takeSnapshotTool,
   resolveUidToSelectorTool,
@@ -65,6 +68,73 @@ describe('Snapshot Tools', () => {
       expect(properties).toBeDefined();
       expect(properties?.uid).toBeDefined();
       expect(required).toContain('uid');
+    });
+
+    it('takeSnapshotTool should have optional saveTo and preview', () => {
+      const { properties } = takeSnapshotTool.inputSchema;
+      expect(properties?.saveTo).toBeDefined();
+      expect(properties?.saveTo.type).toEqual(['boolean', 'string']);
+      expect(properties?.preview).toBeDefined();
+      expect(properties?.preview.type).toBe('number');
+    });
+  });
+
+  describe('Handler: saveTo behavior', () => {
+    const ROOT = {
+      uid: 'uid-root',
+      role: 'main',
+      tag: 'div',
+      children: [
+        { uid: 'uid-1', role: 'button', tag: 'button', name: 'One', children: [] },
+        { uid: 'uid-2', role: 'button', tag: 'button', name: 'Two', children: [] },
+        { uid: 'uid-3', role: 'button', tag: 'button', name: 'Three', children: [] },
+      ],
+    };
+    let tempDir: string;
+
+    beforeEach(() => {
+      tempDir = join(tmpdir(), `snapshot-test-${Date.now()}`);
+
+      vi.doMock('../../src/index.js', () => ({
+        getFirefox: vi.fn().mockResolvedValue({
+          takeSnapshot: vi
+            .fn()
+            .mockResolvedValue({ json: { root: ROOT, snapshotId: 's1', truncated: false } }),
+        }),
+      }));
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+      if (existsSync(tempDir)) {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should save the full snapshot tree ignoring maxLines', async () => {
+      const { handleTakeSnapshot } = await import('../../src/tools/snapshot.js');
+      const filePath = join(tempDir, 'snapshot.txt');
+      const result = await handleTakeSnapshot({ saveTo: filePath, maxLines: 1 });
+
+      expect(result.isError).toBeUndefined();
+      const text = (result.content[0] as { type: 'text'; text: string }).text;
+      expect(text).toContain('Snapshot (id=s1) saved to:');
+      const fileContent = readFileSync(filePath, 'utf8');
+      expect(fileContent).toContain('uid=uid-1');
+      expect(fileContent).toContain('uid=uid-2');
+      expect(fileContent).toContain('uid=uid-3');
+      expect(fileContent.split('\n').length).toBeGreaterThan(1);
+    });
+
+    it('should include a preview when preview is given', async () => {
+      const { handleTakeSnapshot } = await import('../../src/tools/snapshot.js');
+      const result = await handleTakeSnapshot({
+        saveTo: join(tempDir, 'snapshot.txt'),
+        preview: 100,
+      });
+
+      const text = (result.content[0] as { type: 'text'; text: string }).text;
+      expect(text).toContain('Preview:');
     });
   });
 });

--- a/tests/utils/save-output.test.ts
+++ b/tests/utils/save-output.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Unit tests for save-output helper
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import { basename, join, relative, sep } from 'node:path';
+import { tmpdir } from 'node:os';
+import { saveOutput } from '../../src/utils/save-output.js';
+
+const MOCK_HOME = join(tmpdir(), 'save-output-test-home');
+
+vi.mock('node:os', async (importOriginal) => {
+  const os = await importOriginal<typeof import('node:os')>();
+  return { ...os, homedir: () => MOCK_HOME };
+});
+
+describe('saveOutput', () => {
+  const tempDir = join(tmpdir(), `save-output-test-${Date.now()}`);
+
+  afterEach(() => {
+    for (const dir of [tempDir, MOCK_HOME]) {
+      if (existsSync(dir)) {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('should write to an absolute path and report bytes', async () => {
+    const filePath = join(tempDir, 'result.json');
+    const saved = await saveOutput('{"a":1}', filePath, 'evaluate-script');
+
+    expect(saved.path).toBe(filePath);
+    expect(saved.bytes).toBe(7);
+    expect(readFileSync(filePath, 'utf8')).toBe('{"a":1}');
+  });
+
+  it('should create missing parent directories', async () => {
+    const filePath = join(tempDir, 'nested', 'deep', 'result.json');
+    const saved = await saveOutput('data', filePath, 'evaluate-script');
+
+    expect(saved.path).toBe(filePath);
+    expect(existsSync(filePath)).toBe(true);
+  });
+
+  it('should not leave temporary files behind', async () => {
+    const filePath = join(tempDir, 'result.json');
+    await saveOutput('data', filePath, 'evaluate-script');
+
+    expect(readdirSync(tempDir)).toEqual(['result.json']);
+  });
+
+  it('should resolve relative paths against the current working directory', async () => {
+    const filePath = join(tempDir, 'relative.json');
+    const relativePath = relative(process.cwd(), filePath);
+    const saved = await saveOutput('data', relativePath, 'evaluate-script');
+
+    expect(saved.path).toBe(filePath);
+    expect(existsSync(filePath)).toBe(true);
+  });
+
+  it('should generate a timestamped file in the default output dir when no path is given', async () => {
+    const saved = await saveOutput('data', undefined, 'evaluate-script');
+
+    expect(saved.path.startsWith(join(MOCK_HOME, '.firefox-devtools-mcp', 'output') + sep)).toBe(
+      true
+    );
+    expect(saved.path).toContain('evaluate-script-');
+    expect(saved.path.endsWith('.json')).toBe(true);
+    expect(readFileSync(saved.path, 'utf8')).toBe('data');
+  });
+
+  it('should write Buffer content verbatim and report its byte length', async () => {
+    const filePath = join(tempDir, 'image.png');
+    const buffer = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0xff, 0x10]);
+    const saved = await saveOutput(buffer, filePath, 'screenshot', 'png');
+
+    expect(saved.path).toBe(filePath);
+    expect(saved.bytes).toBe(buffer.length);
+    expect(readFileSync(filePath)).toEqual(buffer);
+  });
+
+  it('should use the custom extension in the generated file name', async () => {
+    const saved = await saveOutput('tree', undefined, 'snapshot', 'txt');
+
+    expect(saved.path).toContain('snapshot-');
+    expect(saved.path.endsWith('.txt')).toBe(true);
+  });
+
+  it('should place a generated file inside saveTo when it is an existing directory', async () => {
+    mkdirSync(tempDir, { recursive: true });
+    const saved = await saveOutput('{"a":1}', tempDir, 'network-requests', 'json');
+
+    expect(saved.path.startsWith(tempDir + sep)).toBe(true);
+    expect(basename(saved.path)).toMatch(/^network-requests-.*\.json$/);
+    expect(existsSync(saved.path)).toBe(true);
+  });
+});


### PR DESCRIPTION
Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=2057728

Large tool results currently either bloat the client's context window or get
truncated with data loss; this extends the accepted screenshot saveTo pattern
so the full data goes to disk instead (details and motivation in the bug).

Implements the proposal from the bug: optional saveTo (file path, existing
directory, or true) and preview (character count) on the six bulky-output
tools. The saved file always holds the full untruncated data; the existing
inline truncation limits are unchanged, and responses without saveTo are
identical to before. The screenshot tools are migrated onto the same shared
save helper, with their saveTo widened to also accept true or a directory.

Unit tests cover the save helper and each tool's save/preview paths.
