### PR TITLE
Bug 2057735 - Only save screenshots in the default home folder for the mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Large tool output can consume significant context in CLI clients like Claude Cod
 `evaluate_privileged_script` tools accept an optional `saveTo` parameter that writes the
 result to a file instead of returning it inline. `saveTo` takes one of three forms:
 
-- a file path (absolute, or relative to the current working directory; parent directories are created)
+- a file path (relative to the current working directory, or absolute within `~/.firefox-devtools-mcp`; parent directories are created)
 - an existing directory (a timestamped file is generated inside it)
 - `true` (a timestamped file is generated under `~/.firefox-devtools-mcp/output/`)
 
@@ -227,11 +227,16 @@ of characters of the saved output to echo back inline as a short excerpt. Screen
 preview.
 
 ```
-screenshot_page({ saveTo: "/tmp/page.png" })
+screenshot_page({ saveTo: "page.png" })
 take_snapshot({ saveTo: true })
-list_network_requests({ urlContains: "api", saveTo: "/tmp/net.json" })
+list_network_requests({ urlContains: "api", saveTo: "network.json" })
 evaluate_script({ function: "() => performance.getEntries()", saveTo: true, preview: 2000 })
 ```
+
+By default, save paths are restricted: relative paths resolve against the current working
+directory, and absolute paths are only allowed within `~/.firefox-devtools-mcp`. Paths that
+escape these locations are rejected. Start the server with `--unrestricted-save-paths` to
+write to arbitrary locations, including absolute paths outside that directory.
 
 Saved files can then be viewed with Claude Code's `Read` tool without impacting context size.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -205,6 +205,12 @@ export const cliOptions = {
       'Deprecated: use --tools/--tool-preset. Enable privileged context tools and Firefox prefs tools. Requires MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1.',
     default: (process.env.ENABLE_PRIVILEGED_CONTEXT ?? 'false') === 'true',
   },
+  unrestrictedSavePaths: {
+    type: 'boolean',
+    description:
+      'Allow tools that save files (e.g. screenshots, snapshots, network/console output) to write to arbitrary locations. By default, relative save paths resolve against the current working directory and absolute save paths are restricted to ~/.firefox-devtools-mcp; this flag lifts both restrictions. Use with caution.',
+    default: (process.env.UNRESTRICTED_SAVE_PATHS ?? 'false') === 'true',
+  },
 } satisfies Record<string, YargsOptions>;
 
 export function parseArguments(version: string, argv = process.argv, includePrivileged = true) {

--- a/src/tools/console.ts
+++ b/src/tools/console.ts
@@ -8,6 +8,7 @@ import {
   jsonResponse,
   TOKEN_LIMITS,
   truncateText,
+  previewExcerpt,
 } from '../utils/response-helpers.js';
 import { saveOutput } from '../utils/save-output.js';
 import { defineModule } from './module.js';
@@ -51,7 +52,7 @@ export const listConsoleMessagesTool = {
       saveTo: {
         type: ['boolean', 'string'],
         description:
-          'Save all matching messages to a file in full (no truncation or limit) instead of returning them inline. Pass a file path, an existing directory (generated file inside), or true (generated file under ~/.firefox-devtools-mcp/output/). Relative paths resolve against the current working directory.',
+          'Save matching messages to a file in full (untruncated) instead of returning them inline. Saves all matching messages by default; pass an explicit limit to cap how many are saved. Pass a file path, an existing directory (generated file inside), or true (generated file under ~/.firefox-devtools-mcp/output/). Relative paths resolve against the current working directory.',
       },
       preview: {
         type: 'number',
@@ -135,14 +136,16 @@ export async function handleListConsoleMessages(args: unknown): Promise<McpToolR
       messages = messages.filter((msg) => msg.source?.toLowerCase() === source.toLowerCase());
     }
 
-    if (saveTo && messages.length > 0) {
+    if (saveTo) {
+      const selected = limit !== undefined ? messages.slice(0, limit) : messages;
       const fileBody =
         format === 'json'
           ? JSON.stringify(
               {
                 total: totalCount,
                 filtered: messages.length,
-                messages: messages.map((msg) => ({
+                saved: selected.length,
+                messages: selected.map((msg) => ({
                   level: msg.level,
                   text: msg.text,
                   source: msg.source || null,
@@ -152,17 +155,17 @@ export async function handleListConsoleMessages(args: unknown): Promise<McpToolR
               null,
               2
             )
-          : messages.map(formatMessageLine).join('\n');
+          : selected.map(formatMessageLine).join('\n');
       const saved = await saveOutput(
         fileBody,
         saveTo === true ? undefined : saveTo,
         'console-messages',
         format === 'json' ? 'json' : 'txt'
       );
-      let output = `Console messages (${messages.length} matching, ${totalCount} total) saved to: ${saved.path} (${(saved.bytes / 1024).toFixed(1)}KB)`;
-      if (preview !== undefined && preview > 0) {
-        const previewChars = Math.min(Math.max(preview, 50), TOKEN_LIMITS.MAX_RESPONSE_CHARS);
-        output += '\nPreview:\n' + truncateText(fileBody, previewChars);
+      let output = `Console messages saved to: ${saved.path} (${selected.length} of ${messages.length} matching, ${totalCount} total, ${(saved.bytes / 1024).toFixed(1)}KB)`;
+      const excerpt = previewExcerpt(fileBody, preview);
+      if (excerpt) {
+        output += '\nPreview:\n' + excerpt;
       }
       return successResponse(output);
     }

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -8,8 +8,7 @@ import {
   errorResponse,
   jsonResponse,
   truncateHeaders,
-  truncateText,
-  TOKEN_LIMITS,
+  previewExcerpt,
 } from '../utils/response-helpers.js';
 import { saveOutput } from '../utils/save-output.js';
 import { defineModule } from './module.js';
@@ -79,7 +78,7 @@ export const listNetworkRequestsTool = {
       saveTo: {
         type: ['boolean', 'string'],
         description:
-          'Save all matching requests with full untruncated headers to a file as JSON (ignores limit and detail) instead of returning them inline. Pass a file path, an existing directory (generated file inside), or true (generated file under ~/.firefox-devtools-mcp/output/). Relative paths resolve against the current working directory.',
+          'Save matching requests to a file as JSON instead of returning them inline. Saves full untruncated headers by default; pass detail=summary or min for a lean form, or an explicit limit to cap how many are saved (default: all matching). Pass a file path, an existing directory (generated file inside), or true (generated file under ~/.firefox-devtools-mcp/output/). Relative paths resolve against the current working directory.',
       },
       preview: {
         type: 'number',
@@ -130,7 +129,7 @@ export const getNetworkRequestTool = {
 export async function handleListNetworkRequests(args: unknown): Promise<McpToolResponse> {
   try {
     const {
-      limit = 50,
+      limit,
       sinceMs,
       urlContains,
       method,
@@ -140,7 +139,7 @@ export async function handleListNetworkRequests(args: unknown): Promise<McpToolR
       isXHR,
       resourceType,
       sortBy = 'timestamp',
-      detail = 'summary',
+      detail,
       format = 'text',
       saveTo,
       preview,
@@ -213,23 +212,43 @@ export async function handleListNetworkRequests(args: unknown): Promise<McpToolR
       requests.sort((a, b) => (a.status || 0) - (b.status || 0));
     }
 
-    if (saveTo && requests.length > 0) {
+    if (saveTo) {
+      // Full untruncated headers by default on save; an explicit summary/min
+      // detail selects a lean form. An explicit limit selects the top-N by the
+      // current sort; otherwise all matching requests are saved.
+      const selected = limit !== undefined ? requests.slice(0, limit) : requests;
+      const fileDetail = detail ?? 'full';
       const fileBody = JSON.stringify(
         {
           total: requests.length,
-          requests: requests.map((req) => ({
-            id: req.id,
-            url: req.url,
-            method: req.method,
-            status: req.status ?? null,
-            statusText: req.statusText ?? null,
-            resourceType: req.resourceType ?? null,
-            isXHR: req.isXHR ?? false,
-            timestamp: req.timestamp ?? null,
-            timings: req.timings ?? null,
-            requestHeaders: req.requestHeaders ?? null,
-            responseHeaders: req.responseHeaders ?? null,
-          })),
+          saved: selected.length,
+          detail: fileDetail,
+          requests: selected.map((req) =>
+            fileDetail === 'full'
+              ? {
+                  id: req.id,
+                  url: req.url,
+                  method: req.method,
+                  status: req.status ?? null,
+                  statusText: req.statusText ?? null,
+                  resourceType: req.resourceType ?? null,
+                  isXHR: req.isXHR ?? false,
+                  timestamp: req.timestamp ?? null,
+                  timings: req.timings ?? null,
+                  requestHeaders: req.requestHeaders ?? null,
+                  responseHeaders: req.responseHeaders ?? null,
+                }
+              : {
+                  id: req.id,
+                  url: req.url,
+                  method: req.method,
+                  status: req.status ?? null,
+                  statusText: req.statusText ?? null,
+                  resourceType: req.resourceType ?? null,
+                  isXHR: req.isXHR ?? false,
+                  duration: req.timings?.duration ?? null,
+                }
+          ),
         },
         null,
         2
@@ -239,17 +258,19 @@ export async function handleListNetworkRequests(args: unknown): Promise<McpToolR
         saveTo === true ? undefined : saveTo,
         'network-requests'
       );
-      let output = `${requests.length} network requests saved to: ${saved.path} (${(saved.bytes / 1024).toFixed(1)}KB)`;
-      if (preview !== undefined && preview > 0) {
-        const previewChars = Math.min(Math.max(preview, 50), TOKEN_LIMITS.MAX_RESPONSE_CHARS);
-        output += '\nPreview:\n```json\n' + truncateText(fileBody, previewChars) + '\n```';
+      let output = `Network requests saved to: ${saved.path} (${selected.length} of ${requests.length} matching, ${(saved.bytes / 1024).toFixed(1)}KB)`;
+      const excerpt = previewExcerpt(fileBody, preview);
+      if (excerpt) {
+        output += '\nPreview:\n```json\n' + excerpt + '\n```';
       }
       return successResponse(output);
     }
 
     // Apply limit
-    const limitedRequests = requests.slice(0, limit);
-    const hasMore = requests.length > limit;
+    const effectiveLimit = limit ?? 50;
+    const effectiveDetail = detail ?? 'summary';
+    const limitedRequests = requests.slice(0, effectiveLimit);
+    const hasMore = requests.length > effectiveLimit;
 
     // Format output based on detail level and format
     if (format === 'json') {
@@ -261,7 +282,7 @@ export async function handleListNetworkRequests(args: unknown): Promise<McpToolR
         requests: [],
       };
 
-      if (detail === 'summary' || detail === 'min') {
+      if (effectiveDetail === 'summary' || effectiveDetail === 'min') {
         responseData.requests = limitedRequests.map((req) => ({
           id: req.id,
           url: req.url,
@@ -292,7 +313,7 @@ export async function handleListNetworkRequests(args: unknown): Promise<McpToolR
     }
 
     // Text format (default)
-    if (detail === 'summary') {
+    if (effectiveDetail === 'summary') {
       const formattedRequests = limitedRequests.map((req) => {
         const statusInfo = req.status
           ? `[${req.status}${req.statusText ? ' ' + req.statusText : ''}]`
@@ -300,9 +321,9 @@ export async function handleListNetworkRequests(args: unknown): Promise<McpToolR
         return `${req.id} | ${req.method} ${req.url} ${statusInfo}${req.isXHR ? ' (XHR)' : ''}`;
       });
 
-      const header = `📡 ${requests.length} requests${hasMore ? ` (limit ${limit})` : ''}\n`;
+      const header = `📡 ${requests.length} requests${hasMore ? ` (limit ${effectiveLimit})` : ''}\n`;
       return successResponse(header + formattedRequests.join('\n'));
-    } else if (detail === 'min') {
+    } else if (effectiveDetail === 'min') {
       // Compact JSON
       const minData = limitedRequests.map((req) => ({
         id: req.id,
@@ -316,7 +337,7 @@ export async function handleListNetworkRequests(args: unknown): Promise<McpToolR
       }));
 
       return successResponse(
-        `📡 ${requests.length} requests${hasMore ? ` (limit ${limit})` : ''}\n` +
+        `📡 ${requests.length} requests${hasMore ? ` (limit ${effectiveLimit})` : ''}\n` +
           JSON.stringify(minData, null, 2)
       );
     } else {
@@ -335,7 +356,7 @@ export async function handleListNetworkRequests(args: unknown): Promise<McpToolR
       }));
 
       return successResponse(
-        `📡 ${requests.length} requests${hasMore ? ` (limit ${limit})` : ''}\n` +
+        `📡 ${requests.length} requests${hasMore ? ` (limit ${effectiveLimit})` : ''}\n` +
           JSON.stringify(fullData, null, 2)
       );
     }
@@ -412,9 +433,9 @@ export async function handleGetNetworkRequest(args: unknown): Promise<McpToolRes
         'network-request'
       );
       let output = `Request ${request.id} saved to: ${saved.path} (${(saved.bytes / 1024).toFixed(1)}KB)`;
-      if (preview !== undefined && preview > 0) {
-        const previewChars = Math.min(Math.max(preview, 50), TOKEN_LIMITS.MAX_RESPONSE_CHARS);
-        output += '\nPreview:\n```json\n' + truncateText(fileBody, previewChars) + '\n```';
+      const excerpt = previewExcerpt(fileBody, preview);
+      if (excerpt) {
+        output += '\nPreview:\n```json\n' + excerpt + '\n```';
       }
       return successResponse(output);
     }

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -321,7 +321,7 @@ export async function handleListNetworkRequests(args: unknown): Promise<McpToolR
         return `${req.id} | ${req.method} ${req.url} ${statusInfo}${req.isXHR ? ' (XHR)' : ''}`;
       });
 
-      const header = `📡 ${requests.length} requests${hasMore ? ` (limit ${effectiveLimit})` : ''}\n`;
+      const header = `[network] ${requests.length} requests${hasMore ? ` (limit ${effectiveLimit})` : ''}\n`;
       return successResponse(header + formattedRequests.join('\n'));
     } else if (effectiveDetail === 'min') {
       // Compact JSON
@@ -337,7 +337,7 @@ export async function handleListNetworkRequests(args: unknown): Promise<McpToolR
       }));
 
       return successResponse(
-        `📡 ${requests.length} requests${hasMore ? ` (limit ${effectiveLimit})` : ''}\n` +
+        `[network] ${requests.length} requests${hasMore ? ` (limit ${effectiveLimit})` : ''}\n` +
           JSON.stringify(minData, null, 2)
       );
     } else {
@@ -356,7 +356,7 @@ export async function handleListNetworkRequests(args: unknown): Promise<McpToolR
       }));
 
       return successResponse(
-        `📡 ${requests.length} requests${hasMore ? ` (limit ${effectiveLimit})` : ''}\n` +
+        `[network] ${requests.length} requests${hasMore ? ` (limit ${effectiveLimit})` : ''}\n` +
           JSON.stringify(fullData, null, 2)
       );
     }

--- a/src/tools/privileged-context.ts
+++ b/src/tools/privileged-context.ts
@@ -3,12 +3,7 @@
  * Requires MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1
  */
 
-import {
-  successResponse,
-  errorResponse,
-  truncateText,
-  TOKEN_LIMITS,
-} from '../utils/response-helpers.js';
+import { successResponse, errorResponse, previewExcerpt } from '../utils/response-helpers.js';
 import { validateFunction } from '../utils/js-validation.js';
 import { remoteValueToNative } from '../utils/remote-value.js';
 import { saveOutput } from '../utils/save-output.js';
@@ -195,9 +190,9 @@ export async function handleEvaluatePrivilegedScript(args: unknown): Promise<Mcp
           'evaluate-privileged'
         );
         let output = `Script ran in chrome context. Result saved to: ${saved.path} (${(saved.bytes / 1024).toFixed(1)}KB)`;
-        if (preview !== undefined && preview > 0) {
-          const previewChars = Math.min(Math.max(preview, 50), TOKEN_LIMITS.MAX_RESPONSE_CHARS);
-          output += '\nPreview:\n```json\n' + truncateText(json, previewChars) + '\n```';
+        const excerpt = previewExcerpt(json, preview);
+        if (excerpt) {
+          output += '\nPreview:\n```json\n' + excerpt + '\n```';
         }
         return successResponse(output);
       }

--- a/src/tools/script.ts
+++ b/src/tools/script.ts
@@ -2,12 +2,7 @@
  * JavaScript evaluation tool
  */
 
-import {
-  successResponse,
-  errorResponse,
-  truncateText,
-  TOKEN_LIMITS,
-} from '../utils/response-helpers.js';
+import { successResponse, errorResponse, previewExcerpt } from '../utils/response-helpers.js';
 import { remoteValueToNative } from '../utils/remote-value.js';
 import { validateFunction } from '../utils/js-validation.js';
 import { saveOutput } from '../utils/save-output.js';
@@ -156,10 +151,9 @@ export async function handleEvaluateScript(args: unknown): Promise<McpToolRespon
           'evaluate-script'
         );
         let output = `Script ran on page. Result saved to: ${saved.path} (${(saved.bytes / 1024).toFixed(1)}KB)`;
-        if (preview !== undefined && preview > 0) {
-          // Floor keeps truncateText's suffix from dominating tiny budgets.
-          const previewChars = Math.min(Math.max(preview, 50), TOKEN_LIMITS.MAX_RESPONSE_CHARS);
-          output += '\nPreview:\n```json\n' + truncateText(json, previewChars) + '\n```';
+        const excerpt = previewExcerpt(json, preview);
+        if (excerpt) {
+          output += '\nPreview:\n```json\n' + excerpt + '\n```';
         }
         return successResponse(output);
       }

--- a/src/tools/snapshot.ts
+++ b/src/tools/snapshot.ts
@@ -6,7 +6,7 @@ import {
   successResponse,
   errorResponse,
   TOKEN_LIMITS,
-  truncateText,
+  previewExcerpt,
 } from '../utils/response-helpers.js';
 import { handleUidError } from '../utils/uid-helpers.js';
 import { saveOutput } from '../utils/save-output.js';
@@ -158,9 +158,9 @@ export async function handleTakeSnapshot(args: unknown): Promise<McpToolResponse
       if (snapshot.json.truncated) {
         output += ' [DOM truncated]';
       }
-      if (preview !== undefined && preview > 0) {
-        const previewChars = Math.min(Math.max(preview, 50), TOKEN_LIMITS.MAX_RESPONSE_CHARS);
-        output += '\nPreview:\n' + truncateText(formattedText, previewChars);
+      const excerpt = previewExcerpt(formattedText, preview);
+      if (excerpt) {
+        output += '\nPreview:\n' + excerpt;
       }
       return successResponse(output);
     }

--- a/src/utils/response-helpers.ts
+++ b/src/utils/response-helpers.ts
@@ -46,7 +46,21 @@ export function truncateText(
   if (text.length <= maxChars) {
     return text;
   }
-  return text.slice(0, maxChars - suffix.length) + suffix;
+  // Guard against tiny budgets: maxChars smaller than the suffix would make the
+  // slice length negative and return nearly the whole string.
+  return text.slice(0, Math.max(0, maxChars - suffix.length)) + suffix;
+}
+
+/**
+ * Build an inline preview excerpt of saved output, or an empty string when no
+ * preview was requested. The budget is capped at MAX_RESPONSE_CHARS and a short
+ * ellipsis suffix is used so the budget is spent on content rather than a notice.
+ */
+export function previewExcerpt(text: string, preview: number | undefined): string {
+  if (preview === undefined || preview <= 0) {
+    return '';
+  }
+  return truncateText(text, Math.min(preview, TOKEN_LIMITS.MAX_RESPONSE_CHARS), '...');
 }
 
 /**

--- a/src/utils/save-output.ts
+++ b/src/utils/save-output.ts
@@ -5,11 +5,15 @@
 import { mkdir, rename, stat, unlink, writeFile } from 'node:fs/promises';
 import { randomBytes } from 'node:crypto';
 import { homedir } from 'node:os';
-import { dirname, join, resolve } from 'node:path';
+import { dirname, isAbsolute, join, resolve, sep } from 'node:path';
 
 export interface SavedOutput {
   path: string;
   bytes: number;
+}
+
+function homeRoot(): string {
+  return join(homedir(), '.firefox-devtools-mcp');
 }
 
 function generatedName(baseName: string, extension: string): string {
@@ -26,10 +30,34 @@ async function isDirectory(path: string): Promise<boolean> {
 }
 
 /**
- * Write content to saveTo: a file path (absolute or CWD-relative, parent
- * directories created as needed), or an existing directory (a generated file
- * named after baseName is placed inside). When saveTo is empty, the generated
- * file goes to ~/.firefox-devtools-mcp/output/.
+ * Reject saveTo paths that escape the allowed roots, unless the server was
+ * started with --unrestricted-save-paths. Relative paths must stay within the
+ * current working directory; absolute paths must stay within
+ * ~/.firefox-devtools-mcp.
+ */
+async function assertAllowedPath(saveTo: string, resolvedPath: string): Promise<void> {
+  const { args } = await import('../index.js');
+  if (args?.unrestrictedSavePaths) {
+    return;
+  }
+  const root = isAbsolute(saveTo) ? homeRoot() : process.cwd();
+  if (resolvedPath !== root && !resolvedPath.startsWith(root + sep)) {
+    throw new Error(
+      `saveTo "${saveTo}" resolves outside the allowed location (${resolvedPath}). Relative ` +
+        `paths must stay within the current working directory and absolute paths within ` +
+        `${homeRoot()}. Start the server with --unrestricted-save-paths to write to arbitrary ` +
+        `locations.`
+    );
+  }
+}
+
+/**
+ * Write content to saveTo: a file path (relative to the current working
+ * directory, or absolute within ~/.firefox-devtools-mcp; parent directories are
+ * created as needed), or an existing directory (a generated file named after
+ * baseName is placed inside). When saveTo is empty, the generated file goes to
+ * ~/.firefox-devtools-mcp/output/. Paths escaping the allowed roots are rejected
+ * unless the server runs with --unrestricted-save-paths.
  */
 export async function saveOutput(
   content: string | Buffer,
@@ -43,13 +71,9 @@ export async function saveOutput(
     if (await isDirectory(resolvedPath)) {
       resolvedPath = join(resolvedPath, generatedName(baseName, extension));
     }
+    await assertAllowedPath(saveTo, resolvedPath);
   } else {
-    resolvedPath = join(
-      homedir(),
-      '.firefox-devtools-mcp',
-      'output',
-      generatedName(baseName, extension)
-    );
+    resolvedPath = join(homeRoot(), 'output', generatedName(baseName, extension));
   }
   await mkdir(dirname(resolvedPath), { recursive: true });
 

--- a/tests/tools/console.test.ts
+++ b/tests/tools/console.test.ts
@@ -90,6 +90,7 @@ describe('Console Tools', () => {
       tempDir = join(tmpdir(), `console-test-${Date.now()}`);
 
       vi.doMock('../../src/index.js', () => ({
+        args: { unrestrictedSavePaths: true },
         getFirefox: vi.fn().mockResolvedValue({
           getConsoleMessages: vi.fn().mockResolvedValue(MESSAGES),
         }),

--- a/tests/tools/console.test.ts
+++ b/tests/tools/console.test.ts
@@ -139,13 +139,31 @@ describe('Console Tools', () => {
       expect(parsed.filtered).toBe(3);
     });
 
-    it('should ignore limit when saving to a file', async () => {
+    it('should honor an explicit limit when saving to a file', async () => {
       const { handleListConsoleMessages } = await import('../../src/tools/console.js');
       const filePath = join(tempDir, 'console.json');
       await handleListConsoleMessages({ saveTo: filePath, format: 'json', limit: 1 });
 
       const parsed = JSON.parse(readFileSync(filePath, 'utf8'));
-      expect(parsed.messages).toHaveLength(3);
+      expect(parsed.messages).toHaveLength(1);
+      expect(parsed.saved).toBe(1);
+      expect(parsed.filtered).toBe(3);
+    });
+
+    it('should still write a file when no messages match', async () => {
+      const { handleListConsoleMessages } = await import('../../src/tools/console.js');
+      const filePath = join(tempDir, 'console.json');
+      const result = await handleListConsoleMessages({
+        saveTo: filePath,
+        format: 'json',
+        textContains: 'no-such-message-zzz',
+      });
+
+      expect(result.isError).toBeUndefined();
+      expect((result.content[0] as { type: 'text'; text: string }).text).toContain('saved to:');
+      const parsed = JSON.parse(readFileSync(filePath, 'utf8'));
+      expect(parsed.messages).toHaveLength(0);
+      expect(parsed.saved).toBe(0);
     });
   });
 });

--- a/tests/tools/network.test.ts
+++ b/tests/tools/network.test.ts
@@ -147,14 +147,43 @@ describe('Network Tools', () => {
       expect(raw).not.toContain('__truncated__');
     });
 
-    it('should ignore limit when saving to a file', async () => {
+    it('should honor an explicit limit when saving to a file', async () => {
       const { handleListNetworkRequests } = await import('../../src/tools/network.js');
       const filePath = join(tempDir, 'network.json');
       await handleListNetworkRequests({ saveTo: filePath, limit: 1 });
 
       const parsed = JSON.parse(readFileSync(filePath, 'utf8'));
-      expect(parsed.requests).toHaveLength(2);
+      expect(parsed.requests).toHaveLength(1);
+      expect(parsed.saved).toBe(1);
       expect(parsed.total).toBe(2);
+    });
+
+    it('should save a lean form without headers when detail is summary', async () => {
+      const { handleListNetworkRequests } = await import('../../src/tools/network.js');
+      const filePath = join(tempDir, 'network.json');
+      await handleListNetworkRequests({ saveTo: filePath, detail: 'summary' });
+
+      const raw = readFileSync(filePath, 'utf8');
+      expect(raw).not.toContain(LONG_HEADER);
+      const parsed = JSON.parse(raw);
+      expect(parsed.detail).toBe('summary');
+      expect(parsed.requests[0]).not.toHaveProperty('requestHeaders');
+      expect(parsed.requests[0]).toHaveProperty('duration');
+    });
+
+    it('should still write a file when no requests match', async () => {
+      const { handleListNetworkRequests } = await import('../../src/tools/network.js');
+      const filePath = join(tempDir, 'network.json');
+      const result = await handleListNetworkRequests({
+        saveTo: filePath,
+        urlContains: 'no-such-url-zzz',
+      });
+
+      expect(result.isError).toBeUndefined();
+      expect((result.content[0] as { type: 'text'; text: string }).text).toContain('saved to:');
+      const parsed = JSON.parse(readFileSync(filePath, 'utf8'));
+      expect(parsed.requests).toHaveLength(0);
+      expect(parsed.saved).toBe(0);
     });
 
     it('should save a single request with raw headers by id', async () => {

--- a/tests/tools/network.test.ts
+++ b/tests/tools/network.test.ts
@@ -119,6 +119,7 @@ describe('Network Tools', () => {
       tempDir = join(tmpdir(), `network-test-${Date.now()}`);
 
       vi.doMock('../../src/index.js', () => ({
+        args: { unrestrictedSavePaths: true },
         getFirefox: vi.fn().mockResolvedValue({
           getNetworkRequests: vi.fn().mockResolvedValue(REQUESTS),
         }),

--- a/tests/tools/screenshot.test.ts
+++ b/tests/tools/screenshot.test.ts
@@ -5,8 +5,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { screenshotPageTool, screenshotByUidTool } from '../../src/tools/screenshot.js';
 import { existsSync, readFileSync, rmSync } from 'node:fs';
-import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 const MOCK_HOME = join(tmpdir(), 'screenshot-test-home');
 
@@ -55,12 +55,11 @@ describe('Screenshot Tools', () => {
 
   describe('Handler: saveTo behavior', () => {
     const FAKE_BASE64 = Buffer.from('fake-png-data').toString('base64');
-    let tempDir: string;
+    const tempDir = join(tmpdir(), `screenshot-test-${process.pid}`);
 
     beforeEach(() => {
-      tempDir = join(tmpdir(), `screenshot-test-${Date.now()}`);
-
       vi.doMock('../../src/index.js', () => ({
+        args: { unrestrictedSavePaths: true },
         getFirefox: vi.fn().mockResolvedValue({
           takeScreenshotPage: vi.fn().mockResolvedValue(FAKE_BASE64),
           takeScreenshotByUid: vi.fn().mockResolvedValue(FAKE_BASE64),
@@ -77,7 +76,7 @@ describe('Screenshot Tools', () => {
       }
     });
 
-    it('should save screenshot to file when saveTo is provided (page)', async () => {
+    it('should save screenshot to a file when saveTo is provided (page)', async () => {
       const { handleScreenshotPage } = await import('../../src/tools/screenshot.js');
       const filePath = join(tempDir, 'page.png');
       const result = await handleScreenshotPage({ saveTo: filePath });
@@ -85,24 +84,19 @@ describe('Screenshot Tools', () => {
       expect(result.isError).toBeUndefined();
       expect(result.content).toHaveLength(1);
       expect(result.content[0]).toHaveProperty('type', 'text');
-      expect((result.content[0] as { type: 'text'; text: string }).text).toContain(
-        'Screenshot saved to:'
-      );
-      expect((result.content[0] as { type: 'text'; text: string }).text).toContain('KB)');
+      const text = (result.content[0] as { type: 'text'; text: string }).text;
+      expect(text).toContain('Screenshot saved to:');
+      expect(text).toContain('KB)');
       expect(existsSync(filePath)).toBe(true);
-
-      const written = readFileSync(filePath);
-      expect(written).toEqual(Buffer.from(FAKE_BASE64, 'base64'));
+      expect(readFileSync(filePath)).toEqual(Buffer.from(FAKE_BASE64, 'base64'));
     });
 
-    it('should save screenshot to file when saveTo is provided (by uid)', async () => {
+    it('should save screenshot to a file when saveTo is provided (by uid)', async () => {
       const { handleScreenshotByUid } = await import('../../src/tools/screenshot.js');
       const filePath = join(tempDir, 'element.png');
       const result = await handleScreenshotByUid({ uid: 'test-uid', saveTo: filePath });
 
       expect(result.isError).toBeUndefined();
-      expect(result.content).toHaveLength(1);
-      expect(result.content[0]).toHaveProperty('type', 'text');
       expect((result.content[0] as { type: 'text'; text: string }).text).toContain(
         'Screenshot saved to:'
       );
@@ -116,6 +110,17 @@ describe('Screenshot Tools', () => {
 
       expect(result.isError).toBeUndefined();
       expect(existsSync(filePath)).toBe(true);
+    });
+
+    it('should save to a generated file in the default output dir when saveTo is true', async () => {
+      const { handleScreenshotPage } = await import('../../src/tools/screenshot.js');
+      const result = await handleScreenshotPage({ saveTo: true });
+
+      expect(result.isError).toBeUndefined();
+      const text = (result.content[0] as { type: 'text'; text: string }).text;
+      expect(text).toContain('Screenshot saved to:');
+      expect(text).toContain(join(MOCK_HOME, '.firefox-devtools-mcp', 'output'));
+      expect(text).toContain('screenshot-');
     });
 
     it('should return image content when saveTo is not provided (page)', async () => {
@@ -139,26 +144,38 @@ describe('Screenshot Tools', () => {
       expect(result.content[0]).toHaveProperty('data', FAKE_BASE64);
       expect(result.content[0]).toHaveProperty('mimeType', 'image/png');
     });
+  });
 
-    it('should resolve relative saveTo path', async () => {
-      const { handleScreenshotPage } = await import('../../src/tools/screenshot.js');
-      const relativePath = join(tempDir, 'relative.png');
-      const result = await handleScreenshotPage({ saveTo: relativePath });
+  describe('Handler: saveTo restriction', () => {
+    const FAKE_BASE64 = Buffer.from('fake-png-data').toString('base64');
+    const outside = join(tmpdir(), `screenshot-restrict-${process.pid}.png`);
 
-      expect(result.isError).toBeUndefined();
-      expect((result.content[0] as { type: 'text'; text: string }).text).toContain(relativePath);
-      expect(existsSync(relativePath)).toBe(true);
+    beforeEach(() => {
+      vi.doMock('../../src/index.js', () => ({
+        args: { unrestrictedSavePaths: false },
+        getFirefox: vi.fn().mockResolvedValue({
+          takeScreenshotPage: vi.fn().mockResolvedValue(FAKE_BASE64),
+          takeScreenshotByUid: vi.fn().mockResolvedValue(FAKE_BASE64),
+        }),
+      }));
     });
 
-    it('should save to a generated file in the default output dir when saveTo is true', async () => {
-      const { handleScreenshotPage } = await import('../../src/tools/screenshot.js');
-      const result = await handleScreenshotPage({ saveTo: true });
+    afterEach(() => {
+      vi.restoreAllMocks();
+      if (existsSync(outside)) {
+        rmSync(outside, { force: true });
+      }
+    });
 
-      expect(result.isError).toBeUndefined();
-      const text = (result.content[0] as { type: 'text'; text: string }).text;
-      expect(text).toContain('Screenshot saved to:');
-      expect(text).toContain(join(MOCK_HOME, '.firefox-devtools-mcp', 'output'));
-      expect(text).toContain('screenshot-');
+    it('should reject an absolute saveTo outside the allowed directory', async () => {
+      const { handleScreenshotPage } = await import('../../src/tools/screenshot.js');
+      const result = await handleScreenshotPage({ saveTo: outside });
+
+      expect(result.isError).toBe(true);
+      expect((result.content[0] as { type: 'text'; text: string }).text).toContain(
+        '--unrestricted-save-paths'
+      );
+      expect(existsSync(outside)).toBe(false);
     });
   });
 });

--- a/tests/tools/script.test.ts
+++ b/tests/tools/script.test.ts
@@ -74,6 +74,7 @@ describe('Script Tools', () => {
       tempDir = join(tmpdir(), `script-test-${Date.now()}`);
 
       vi.doMock('../../src/index.js', () => ({
+        args: { unrestrictedSavePaths: true },
         getFirefox: vi.fn().mockResolvedValue({
           getCurrentContextId: vi.fn().mockReturnValue('ctx-1'),
           sendBiDiCommand: vi.fn().mockResolvedValue({
@@ -139,6 +140,7 @@ describe('Script Tools', () => {
     it('should save the string "undefined" when the script returns undefined', async () => {
       vi.resetModules();
       vi.doMock('../../src/index.js', () => ({
+        args: { unrestrictedSavePaths: true },
         getFirefox: vi.fn().mockResolvedValue({
           getCurrentContextId: vi.fn().mockReturnValue('ctx-1'),
           sendBiDiCommand: vi.fn().mockResolvedValue({

--- a/tests/tools/script.test.ts
+++ b/tests/tools/script.test.ts
@@ -120,7 +120,9 @@ describe('Script Tools', () => {
       expect(result.isError).toBeUndefined();
       const text = (result.content[0] as { type: 'text'; text: string }).text;
       expect(text).toContain('Preview:');
-      expect(text).toContain('[... truncated');
+      // Truncated previews end with a short ellipsis rather than the full value.
+      expect(text).toContain('...');
+      expect(text).not.toContain(RESULT_VALUE);
     });
 
     it('should treat non-positive preview as no preview', async () => {

--- a/tests/tools/snapshot.test.ts
+++ b/tests/tools/snapshot.test.ts
@@ -96,6 +96,7 @@ describe('Snapshot Tools', () => {
       tempDir = join(tmpdir(), `snapshot-test-${Date.now()}`);
 
       vi.doMock('../../src/index.js', () => ({
+        args: { unrestrictedSavePaths: true },
         getFirefox: vi.fn().mockResolvedValue({
           takeSnapshot: vi
             .fn()

--- a/tests/utils/response-helpers-extended.test.ts
+++ b/tests/utils/response-helpers-extended.test.ts
@@ -3,7 +3,14 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { successResponse, errorResponse, jsonResponse } from '../../src/utils/response-helpers.js';
+import {
+  successResponse,
+  errorResponse,
+  jsonResponse,
+  truncateText,
+  previewExcerpt,
+  TOKEN_LIMITS,
+} from '../../src/utils/response-helpers.js';
 
 describe('Response Helpers - Extended', () => {
   describe('successResponse', () => {
@@ -185,6 +192,46 @@ describe('Response Helpers - Extended', () => {
       expect(success.content[0].type).toBe('text');
       expect(error.content[0].type).toBe('text');
       expect(json.content[0].type).toBe('text');
+    });
+  });
+
+  describe('truncateText', () => {
+    it('should return text unchanged when within the budget', () => {
+      expect(truncateText('short', 100)).toBe('short');
+    });
+
+    it('should not blow up when the budget is smaller than the suffix', () => {
+      const long = 'x'.repeat(1000);
+      const result = truncateText(long, 5, '...');
+      // Would return nearly the whole string if the slice length went negative.
+      expect(result.length).toBeLessThan(20);
+      expect(result.endsWith('...')).toBe(true);
+    });
+  });
+
+  describe('previewExcerpt', () => {
+    it('should return an empty string when preview is omitted or non-positive', () => {
+      expect(previewExcerpt('data', undefined)).toBe('');
+      expect(previewExcerpt('data', 0)).toBe('');
+      expect(previewExcerpt('data', -5)).toBe('');
+    });
+
+    it('should return the full text when it fits within the requested budget', () => {
+      expect(previewExcerpt('hello', 100)).toBe('hello');
+    });
+
+    it('should truncate with an ellipsis and stay near the requested budget', () => {
+      const long = 'y'.repeat(1000);
+      const excerpt = previewExcerpt(long, 100);
+      expect(excerpt.endsWith('...')).toBe(true);
+      expect(excerpt.length).toBeLessThanOrEqual(100);
+      expect(excerpt.length).toBeGreaterThan(50);
+    });
+
+    it('should cap the budget at MAX_RESPONSE_CHARS', () => {
+      const huge = 'z'.repeat(TOKEN_LIMITS.MAX_RESPONSE_CHARS * 2);
+      const excerpt = previewExcerpt(huge, TOKEN_LIMITS.MAX_RESPONSE_CHARS * 2);
+      expect(excerpt.length).toBeLessThanOrEqual(TOKEN_LIMITS.MAX_RESPONSE_CHARS);
     });
   });
 });

--- a/tests/utils/save-output.test.ts
+++ b/tests/utils/save-output.test.ts
@@ -2,97 +2,136 @@
  * Unit tests for save-output helper
  */
 
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync } from 'node:fs';
 import { basename, join, relative, sep } from 'node:path';
 import { tmpdir } from 'node:os';
-import { saveOutput } from '../../src/utils/save-output.js';
 
 const MOCK_HOME = join(tmpdir(), 'save-output-test-home');
+const HOME_ROOT = join(MOCK_HOME, '.firefox-devtools-mcp');
 
 vi.mock('node:os', async (importOriginal) => {
   const os = await importOriginal<typeof import('node:os')>();
   return { ...os, homedir: () => MOCK_HOME };
 });
 
+const mockArgs = vi.hoisted(() => ({ unrestrictedSavePaths: false }));
+vi.mock('../../src/index.js', () => ({ args: mockArgs }));
+
+import { saveOutput } from '../../src/utils/save-output.js';
+
 describe('saveOutput', () => {
-  const tempDir = join(tmpdir(), `save-output-test-${Date.now()}`);
+  const tempDir = join(tmpdir(), `save-output-test-${process.pid}`);
+  const cwdDir = join(process.cwd(), `save-output-cwd-${process.pid}`);
+
+  beforeEach(() => {
+    mockArgs.unrestrictedSavePaths = false;
+  });
 
   afterEach(() => {
-    for (const dir of [tempDir, MOCK_HOME]) {
+    for (const dir of [tempDir, MOCK_HOME, cwdDir]) {
       if (existsSync(dir)) {
         rmSync(dir, { recursive: true, force: true });
       }
     }
   });
 
-  it('should write to an absolute path and report bytes', async () => {
-    const filePath = join(tempDir, 'result.json');
-    const saved = await saveOutput('{"a":1}', filePath, 'evaluate-script');
+  describe('write behavior (unrestricted)', () => {
+    beforeEach(() => {
+      mockArgs.unrestrictedSavePaths = true;
+    });
 
-    expect(saved.path).toBe(filePath);
-    expect(saved.bytes).toBe(7);
-    expect(readFileSync(filePath, 'utf8')).toBe('{"a":1}');
+    it('should write to an absolute path and report bytes', async () => {
+      const filePath = join(tempDir, 'result.json');
+      const saved = await saveOutput('{"a":1}', filePath, 'evaluate-script');
+
+      expect(saved.path).toBe(filePath);
+      expect(saved.bytes).toBe(7);
+      expect(readFileSync(filePath, 'utf8')).toBe('{"a":1}');
+    });
+
+    it('should create missing parent directories', async () => {
+      const filePath = join(tempDir, 'nested', 'deep', 'result.json');
+      const saved = await saveOutput('data', filePath, 'evaluate-script');
+
+      expect(saved.path).toBe(filePath);
+      expect(existsSync(filePath)).toBe(true);
+    });
+
+    it('should not leave temporary files behind', async () => {
+      const filePath = join(tempDir, 'result.json');
+      await saveOutput('data', filePath, 'evaluate-script');
+
+      expect(readdirSync(tempDir)).toEqual(['result.json']);
+    });
+
+    it('should write Buffer content verbatim and report its byte length', async () => {
+      const filePath = join(tempDir, 'image.png');
+      const buffer = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0xff, 0x10]);
+      const saved = await saveOutput(buffer, filePath, 'screenshot', 'png');
+
+      expect(saved.path).toBe(filePath);
+      expect(saved.bytes).toBe(buffer.length);
+      expect(readFileSync(filePath)).toEqual(buffer);
+    });
+
+    it('should place a generated file inside saveTo when it is an existing directory', async () => {
+      mkdirSync(tempDir, { recursive: true });
+      const saved = await saveOutput('{"a":1}', tempDir, 'network-requests', 'json');
+
+      expect(saved.path.startsWith(tempDir + sep)).toBe(true);
+      expect(basename(saved.path)).toMatch(/^network-requests-.*\.json$/);
+      expect(existsSync(saved.path)).toBe(true);
+    });
   });
 
-  it('should create missing parent directories', async () => {
-    const filePath = join(tempDir, 'nested', 'deep', 'result.json');
-    const saved = await saveOutput('data', filePath, 'evaluate-script');
+  describe('path restriction (default)', () => {
+    it('should allow a relative path within the current working directory', async () => {
+      const filePath = join(cwdDir, 'result.json');
+      const relativePath = relative(process.cwd(), filePath);
+      const saved = await saveOutput('data', relativePath, 'evaluate-script');
 
-    expect(saved.path).toBe(filePath);
-    expect(existsSync(filePath)).toBe(true);
-  });
+      expect(saved.path).toBe(filePath);
+      expect(existsSync(filePath)).toBe(true);
+    });
 
-  it('should not leave temporary files behind', async () => {
-    const filePath = join(tempDir, 'result.json');
-    await saveOutput('data', filePath, 'evaluate-script');
+    it('should reject a relative path that escapes the current working directory', async () => {
+      const escaping = join('..', `save-output-escape-${process.pid}.json`);
+      await expect(saveOutput('data', escaping, 'evaluate-script')).rejects.toThrow(
+        '--unrestricted-save-paths'
+      );
+    });
 
-    expect(readdirSync(tempDir)).toEqual(['result.json']);
-  });
+    it('should allow an absolute path within ~/.firefox-devtools-mcp', async () => {
+      const filePath = join(HOME_ROOT, 'sub', 'result.json');
+      const saved = await saveOutput('data', filePath, 'evaluate-script');
 
-  it('should resolve relative paths against the current working directory', async () => {
-    const filePath = join(tempDir, 'relative.json');
-    const relativePath = relative(process.cwd(), filePath);
-    const saved = await saveOutput('data', relativePath, 'evaluate-script');
+      expect(saved.path).toBe(filePath);
+      expect(existsSync(filePath)).toBe(true);
+    });
 
-    expect(saved.path).toBe(filePath);
-    expect(existsSync(filePath)).toBe(true);
-  });
+    it('should reject an absolute path outside ~/.firefox-devtools-mcp', async () => {
+      const filePath = join(tempDir, 'result.json');
+      await expect(saveOutput('data', filePath, 'evaluate-script')).rejects.toThrow(
+        '--unrestricted-save-paths'
+      );
+      expect(existsSync(filePath)).toBe(false);
+    });
 
-  it('should generate a timestamped file in the default output dir when no path is given', async () => {
-    const saved = await saveOutput('data', undefined, 'evaluate-script');
+    it('should generate a timestamped file in the default output dir when no path is given', async () => {
+      const saved = await saveOutput('data', undefined, 'evaluate-script');
 
-    expect(saved.path.startsWith(join(MOCK_HOME, '.firefox-devtools-mcp', 'output') + sep)).toBe(
-      true
-    );
-    expect(saved.path).toContain('evaluate-script-');
-    expect(saved.path.endsWith('.json')).toBe(true);
-    expect(readFileSync(saved.path, 'utf8')).toBe('data');
-  });
+      expect(saved.path.startsWith(join(HOME_ROOT, 'output') + sep)).toBe(true);
+      expect(saved.path).toContain('evaluate-script-');
+      expect(saved.path.endsWith('.json')).toBe(true);
+      expect(readFileSync(saved.path, 'utf8')).toBe('data');
+    });
 
-  it('should write Buffer content verbatim and report its byte length', async () => {
-    const filePath = join(tempDir, 'image.png');
-    const buffer = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0xff, 0x10]);
-    const saved = await saveOutput(buffer, filePath, 'screenshot', 'png');
+    it('should use the custom extension in the generated file name', async () => {
+      const saved = await saveOutput('tree', undefined, 'snapshot', 'txt');
 
-    expect(saved.path).toBe(filePath);
-    expect(saved.bytes).toBe(buffer.length);
-    expect(readFileSync(filePath)).toEqual(buffer);
-  });
-
-  it('should use the custom extension in the generated file name', async () => {
-    const saved = await saveOutput('tree', undefined, 'snapshot', 'txt');
-
-    expect(saved.path).toContain('snapshot-');
-    expect(saved.path.endsWith('.txt')).toBe(true);
-  });
-
-  it('should place a generated file inside saveTo when it is an existing directory', async () => {
-    mkdirSync(tempDir, { recursive: true });
-    const saved = await saveOutput('{"a":1}', tempDir, 'network-requests', 'json');
-
-    expect(saved.path.startsWith(tempDir + sep)).toBe(true);
-    expect(basename(saved.path)).toMatch(/^network-requests-.*\.json$/);
-    expect(existsSync(saved.path)).toBe(true);
+      expect(saved.path).toContain('snapshot-');
+      expect(saved.path.endsWith('.txt')).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
By default screenshots can only be saved under ~/.firefox-devtools/mcp

A cli parameter `--unrestricted-save-paths` is added to bypass this restriction. 
This parameter should also be reused for any future save-to-file / save-location 
feature exposed by the mcp (profiles, screencasts, response bodies etc...).