### PR TITLE
fix: Update tool presets based on actual usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ You can pass flags or environment variables (names on the right):
 - `--pref name=value` — set Firefox preference at startup via `moz:firefoxOptions` (repeatable)
 - `--tool-preset` — select which tool modules to enable: `slim`, `basic` (default), `developer`, `mozilla`, or `all`. See [Tool modules and presets](#tool-modules-and-presets). (`TOOL_PRESET`)
 - `--tools` — explicit list of tool modules to enable, overriding `--tool-preset` entirely (e.g. `--tools pages network script`). See [Tool modules and presets](#tool-modules-and-presets).
-- `--enable-script` — _deprecated, use `--tool-preset developer` or `--tools ... script debugging`._ Enables the script and debugging tools. (`ENABLE_SCRIPT=true`)
-- `--enable-privileged-context` — _deprecated, use `--tool-preset mozilla` or `--tools ... privileged prefs`._ Enables privileged context and Firefox prefs tools. Requires `MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1` (`ENABLE_PRIVILEGED_CONTEXT=true`)
+- `--enable-script` — _deprecated, use `--tool-preset developer` or `--tools ... script debugging`._ Selects the `developer` tool preset. (`ENABLE_SCRIPT=true`)
+- `--enable-privileged-context` — _deprecated, use `--tool-preset mozilla` or `--tools ... privileged prefs`._  Selects the `mozilla` tool preset. Requires `MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1` (`ENABLE_PRIVILEGED_CONTEXT=true`)
 - `--android-device` — enable Firefox for Android mode; value is the ADB device serial (e.g. `emulator-5554`). Run `adb devices` to list connected devices. Omit the value or use `auto` to select the single connected device automatically.
 - `--android-package` — Android app package name, default `org.mozilla.firefox`. Other packages: `org.mozilla.firefox_beta` for Firefox Beta, `org.mozilla.fenix` for Firefox Nightly, `org.mozilla.fenix.debug` for Firefox Nightly Debug, `org.mozilla.geckoview_example` for geckoview (`ANDROID_PACKAGE`)
 - `--log-file` — write MCP server logs to a file instead of stderr. Useful for debugging sessions with MCP clients that hide server output. Set `DEBUG=*` to also include verbose debug logs. Example: `--log-file /tmp/firefox-mcp.log`

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -53,18 +53,24 @@ export const MODULES: ToolModule[] = [
 
 export const MODULE_NAMES = MODULES.map((m) => m.name);
 
-const SLIM = ['pages', 'snapshot', 'input', 'network', 'console'];
+// SLIM: Minimum set of tools to navigate and browser the web efficiently.
+const SLIM = ['pages', 'snapshot', 'input', 'screenshot'];
+// BASIC: Additional tools useful for regular web-browsing.
 const BASIC = [
   ...SLIM,
-  'screenshot',
   'downloads',
+  // script is often used as a workaround by agents when they can't deal with
+  // the page using high level tools.
+  'script',
   'utilities',
   'management',
   'webextension',
-  'profiler',
   'screencast',
 ];
-const DEVELOPER = [...BASIC, 'script', 'debugging'];
+// DEVELOPER: Tools only useful for web developers / firefox developers.
+const DEVELOPER = [...BASIC, 'debugging', 'network', 'console', 'profiler'];
+// MOZILLA: (all tools) Also includes privileged tools only useful for firefox
+// developers.
 const MOZILLA = [...DEVELOPER, 'prefs', 'privileged'];
 
 export const PRESETS: Record<string, string[]> = {

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -45,8 +45,8 @@ export function buildToolset(options: ToolsetOptions): Toolset {
  *
  * - `tools`, when provided, replaces the preset entirely (exact module set).
  * - Otherwise the named `preset` applies (default: basic).
- * - Legacy `enableScript` / `enablePrivilegedContext` flags add modules on top
- *   and emit deprecation warnings.
+ * - Legacy `enableScript` / `enablePrivilegedContext` flags force the
+ *   `developer` / `mozilla` presets on top and emit deprecation warnings.
  * - Privileged modules are dropped when `allowPrivileged` is false (public build).
  */
 function selectModules(options: ToolsetOptions): { moduleNames: string[]; warnings: string[] } {
@@ -89,8 +89,9 @@ function selectModules(options: ToolsetOptions): { moduleNames: string[]; warnin
       warnings.push('--enable-script is ignored when --tools is set; add "script" to --tools.');
     } else {
       warnings.push('--enable-script is deprecated; use --tools/--tool-preset instead.');
-      add('script');
-      add('debugging');
+      for (const name of PRESETS.developer ?? []) {
+        add(name);
+      }
     }
   }
   if (enablePrivilegedContext) {
@@ -102,8 +103,9 @@ function selectModules(options: ToolsetOptions): { moduleNames: string[]; warnin
       warnings.push(
         '--enable-privileged-context is deprecated; use --tools/--tool-preset instead.'
       );
-      add('privileged');
-      add('prefs');
+      for (const name of PRESETS.mozilla ?? []) {
+        add(name);
+      }
     }
   }
 

--- a/tests/tools/registry.test.ts
+++ b/tests/tools/registry.test.ts
@@ -76,8 +76,7 @@ describe('Tool registry', () => {
       expect([...PRESETS.all].sort()).toEqual(MODULES.map((m) => m.name).sort());
     });
 
-    it('basic (default) excludes script, debugging, prefs, and privileged', () => {
-      expect(PRESETS[DEFAULT_PRESET]).not.toContain('script');
+    it('basic (default) excludes debugging, prefs, and privileged', () => {
       expect(PRESETS[DEFAULT_PRESET]).not.toContain('debugging');
       expect(PRESETS[DEFAULT_PRESET]).not.toContain('prefs');
       expect(PRESETS[DEFAULT_PRESET]).not.toContain('privileged');
@@ -95,7 +94,9 @@ describe('Tool registry', () => {
 
     it('honors an explicit preset', () => {
       const { moduleNames } = buildToolset({ preset: 'slim' });
-      expect(moduleNames).toEqual(['pages', 'snapshot', 'input', 'network', 'console']);
+      expect(moduleNames).toEqual(
+        MODULES.map((m) => m.name).filter((n) => PRESETS.slim.includes(n))
+      );
     });
 
     it('lets --tools replace the preset entirely', () => {
@@ -119,20 +120,22 @@ describe('Tool registry', () => {
       expect(warnings.some((w) => w.includes('nope'))).toBe(true);
     });
 
-    it('treats --enable-script as a deprecated alias for script + debugging', () => {
+    it('treats --enable-script as a deprecated alias for the developer preset', () => {
       const { moduleNames, warnings } = buildToolset({ enableScript: true });
-      expect(moduleNames).toContain('script');
-      expect(moduleNames).toContain('debugging');
+      for (const name of PRESETS.developer) {
+        expect(moduleNames).toContain(name);
+      }
       expect(warnings.some((w) => w.includes('--enable-script is deprecated'))).toBe(true);
     });
 
-    it('treats --enable-privileged-context as a deprecated alias for privileged + prefs', () => {
+    it('treats --enable-privileged-context as a deprecated alias for the mozilla preset', () => {
       const { moduleNames, warnings } = buildToolset({
         enablePrivilegedContext: true,
         allowPrivileged: true,
       });
-      expect(moduleNames).toContain('privileged');
-      expect(moduleNames).toContain('prefs');
+      for (const name of PRESETS.mozilla) {
+        expect(moduleNames).toContain(name);
+      }
       expect(warnings.some((w) => w.includes('--enable-privileged-context is deprecated'))).toBe(
         true
       );
@@ -161,8 +164,9 @@ describe('Tool registry', () => {
 
     it('still applies legacy flags on top of a preset', () => {
       const { moduleNames } = buildToolset({ preset: 'basic', enableScript: true });
-      expect(moduleNames).toContain('script');
-      expect(moduleNames).toContain('debugging');
+      for (const name of PRESETS.developer) {
+        expect(moduleNames).toContain(name);
+      }
     });
 
     it('drops privileged modules when not allowed, with a warning', () => {


### PR DESCRIPTION
Initial tool split in preset was not very accurate. Screenshot is almost always mandatory.
Script is useful in many browsing scenarios.
Profiler makes only sense for developers.