### PR TITLE
Bug 2058226 - [firefox-devtools-mcp] Add tool to get page text

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Both flags are required because the MCP uses both WebDriver Classic (`--marionet
 
 ## Tool overview
 
-- Pages: list/new/navigate/select/close
+- Pages: list/new/navigate/select/close/get_page_text (get_page_text supports optional `saveTo`)
 - Snapshot/UID: take/resolve/clear (take supports optional `saveTo`)
 - Input: click/hover/fill/drag/upload/form fill
 - Network: list/get (ID‑first, filters, always‑on capture; both support optional `saveTo`)
@@ -212,7 +212,8 @@ Both flags are required because the MCP uses both WebDriver Classic (`--marionet
 
 Large tool output can consume significant context in CLI clients like Claude Code. The
 `screenshot_page`, `screenshot_by_uid`, `take_snapshot`, `list_console_messages`,
-`list_network_requests`, `get_network_request`, `evaluate_script`, and
+`list_network_requests`, `get_network_request`, `get_page_text`,
+`evaluate_script`, and
 `evaluate_privileged_script` tools accept an optional `saveTo` parameter that writes the
 result to a file instead of returning it inline. `saveTo` takes one of three forms:
 
@@ -240,7 +241,7 @@ directory, and absolute paths are only allowed within `~/.firefox-devtools-mcp`.
 escape these locations are rejected. Start the server with `--unrestricted-save-paths` to
 write to arbitrary locations, including absolute paths outside that directory.
 
-Saved files can then be viewed with Claude Code's `Read` tool without impacting context size.
+Saved files can then be viewed for instance with Claude Code's `Read` tool without impacting context size.
 
 ## Local development
 

--- a/src/firefox/dom.ts
+++ b/src/firefox/dom.ts
@@ -10,21 +10,6 @@ export class DomInteractions {
     private resolveUid?: (uid: string) => Promise<WebElement>
   ) {}
 
-  /**
-   * Evaluate JavaScript - direct passthrough to executeScript
-   */
-  async evaluate(script: string): Promise<unknown> {
-    return await this.driver.executeScript(script);
-  }
-
-  /**
-   * Get page HTML content
-   */
-  async getContent(): Promise<string> {
-    const html = await this.evaluate('return document.documentElement.outerHTML');
-    return String(html);
-  }
-
   // ============================================================================
   // Element polling helpers
   // ============================================================================

--- a/src/firefox/index.ts
+++ b/src/firefox/index.ts
@@ -6,6 +6,7 @@ import type { FirefoxLaunchOptions, ConsoleMessage, LogpointResult } from './typ
 import { WebElement } from 'selenium-webdriver';
 import { FirefoxCore } from './core.js';
 import { logDebug } from '../utils/logger.js';
+import { remoteValueToNative } from '../utils/remote-value.js';
 import { ConsoleEvents, NetworkEvents, DebuggingEvents, DownloadEvents } from './events/index.js';
 import { DomInteractions } from './dom.js';
 import { PageManagement } from './pages.js';
@@ -129,18 +130,24 @@ export class FirefoxClient {
   // DOM / Evaluate
   // ============================================================================
 
-  async evaluate(script: string): Promise<unknown> {
-    if (!this.dom) {
-      throw new Error('Not connected');
+  /**
+   * Evaluate a JavaScript expression in the current browsing context over
+   * WebDriver BiDi (script.evaluate), so reads target the BiDi-tracked context
+   * rather than Selenium's classic window handle. Returns the result as a
+   * native value; throws on a script exception.
+   */
+  async evaluate(expression: string): Promise<unknown> {
+    const result = await this.core.sendBiDiCommand('script.evaluate', {
+      expression,
+      awaitPromise: true,
+      target: { context: this.core.getCurrentContextId() },
+    });
+    if (result.type === 'success') {
+      return remoteValueToNative(result.result);
     }
-    return await this.dom.evaluate(script);
-  }
-
-  async getContent(): Promise<string> {
-    if (!this.dom) {
-      throw new Error('Not connected');
-    }
-    return await this.dom.getContent();
+    throw new Error(
+      `Script evaluation failed: ${result.exceptionDetails?.text ?? 'unknown error'}`
+    );
   }
 
   async clickBySelector(selector: string): Promise<void> {

--- a/src/tools/pages.ts
+++ b/src/tools/pages.ts
@@ -2,9 +2,17 @@
  * Page navigation and management tools for MCP
  */
 
-import { successResponse, errorResponse } from '../utils/response-helpers.js';
+import {
+  successResponse,
+  errorResponse,
+  previewExcerpt,
+  truncationFooter,
+} from '../utils/response-helpers.js';
+import { saveOutput } from '../utils/save-output.js';
 import { defineModule } from './module.js';
 import type { McpToolResponse } from '../types/common.js';
+
+const DEFAULT_MAX_CONTENT_CHARS = 20_000;
 
 // Tool definitions
 export const listPagesTool = {
@@ -96,6 +104,35 @@ export const closePageTool = {
       },
     },
     required: ['pageIdx'],
+  },
+};
+
+export const getPageTextTool = {
+  name: 'get_page_text',
+  description:
+    'Get the visible text of the page (document.body.innerText). Caps at maxLength (default 20000 chars); saveTo saves the full text to a file.',
+  annotations: {
+    readOnlyHint: true,
+  },
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      maxLength: {
+        type: 'number',
+        description:
+          'Max characters to return inline (default: 20000). Ignored when saveTo is used.',
+      },
+      saveTo: {
+        type: ['boolean', 'string'],
+        description:
+          'Save the full untruncated text to a file instead of returning it inline. Pass a file path, an existing directory (generated file inside), or true (generated file under ~/.firefox-devtools-mcp/output/). Relative paths resolve against the current working directory.',
+      },
+      preview: {
+        type: 'number',
+        description:
+          'Number of characters of the saved text to return inline as a preview when saveTo is used. Omit for no preview.',
+      },
+    },
   },
 };
 
@@ -264,6 +301,61 @@ export async function handleClosePage(args: unknown): Promise<McpToolResponse> {
   }
 }
 
+async function respondWithContent(
+  content: string,
+  args: unknown,
+  baseName: string,
+  extension: string
+): Promise<McpToolResponse> {
+  const {
+    maxLength = DEFAULT_MAX_CONTENT_CHARS,
+    saveTo,
+    preview,
+  } = (args as { maxLength?: number; saveTo?: boolean | string; preview?: number }) || {};
+
+  if (saveTo) {
+    const saved = await saveOutput(
+      content,
+      saveTo === true ? undefined : saveTo,
+      baseName,
+      extension
+    );
+    let output = `${baseName} saved to: ${saved.path} (${(saved.bytes / 1024).toFixed(1)}KB)`;
+    const excerpt = previewExcerpt(content, preview);
+    if (excerpt) {
+      output += '\nPreview:\n' + excerpt;
+    }
+    return successResponse(output);
+  }
+
+  // Always end with a status marker so the model can tell "this is everything"
+  // from "this was cut" instead of inferring completeness from a missing footer.
+  if (content.length <= maxLength) {
+    return successResponse(content + `\n\n[full content, ${content.length} chars]`);
+  }
+
+  const footer = truncationFooter(content.length - maxLength, 'chars', [
+    'maxLength to show more',
+    'saveTo to save the full content to a file',
+  ]);
+  return successResponse(content.slice(0, maxLength) + '\n\n' + footer);
+}
+
+export async function handleGetPageText(args: unknown): Promise<McpToolResponse> {
+  try {
+    const { getFirefox } = await import('../index.js');
+    const firefox = await getFirefox();
+
+    const text = (await firefox.evaluate(
+      'document.body ? document.body.innerText : document.documentElement.innerText'
+    )) as string | null | undefined;
+
+    return respondWithContent(text ?? '', args, 'page-text', 'txt');
+  } catch (error) {
+    return errorResponse(error as Error);
+  }
+}
+
 export const module = defineModule({
   name: 'pages',
   description: 'Open, navigate, select, and close pages.',
@@ -273,5 +365,6 @@ export const module = defineModule({
     [navigatePageTool, handleNavigatePage],
     [selectPageTool, handleSelectPage],
     [closePageTool, handleClosePage],
+    [getPageTextTool, handleGetPageText],
   ],
 });

--- a/tests/integration/e2e-scenario.integration.test.ts
+++ b/tests/integration/e2e-scenario.integration.test.ts
@@ -96,7 +96,7 @@ describe('E2E Scenario: Todo App Workflow', () => {
   }, 20000);
 
   it('should evaluate JavaScript to check app state', async () => {
-    const result = await firefox.evaluate('return document.getElementById("status").textContent');
+    const result = await firefox.evaluate('document.getElementById("status").textContent');
     expect(result).toBeDefined();
     expect(typeof result).toBe('string');
   }, 10000);
@@ -129,9 +129,7 @@ describe('E2E Scenario: Click Interactions', () => {
     await firefox.clickByUid(dblBtn.uid, true);
     await waitForPageLoad(200);
 
-    const result = await firefox.evaluate(
-      'return document.getElementById("dblClickResult").textContent'
-    );
+    const result = await firefox.evaluate('document.getElementById("dblClickResult").textContent');
     expect(result).toBe('Double-clicked!');
   }, 15000);
 
@@ -145,9 +143,7 @@ describe('E2E Scenario: Click Interactions', () => {
     await firefox.hoverByUid(hoverBtn.uid);
     await waitForPageLoad(200);
 
-    const result = await firefox.evaluate(
-      'return document.getElementById("hoverResult").textContent'
-    );
+    const result = await firefox.evaluate('document.getElementById("hoverResult").textContent');
     expect(result).toBe('Hovered!');
   }, 15000);
 });
@@ -272,14 +268,14 @@ describe('E2E Scenario: Viewport Resize', () => {
     await firefox.setViewportSize(800, 600);
     await waitForPageLoad(200);
 
-    const smallWidth = (await firefox.evaluate('return window.innerWidth')) as number;
-    const smallHeight = (await firefox.evaluate('return window.innerHeight')) as number;
+    const smallWidth = (await firefox.evaluate('window.innerWidth')) as number;
+    const smallHeight = (await firefox.evaluate('window.innerHeight')) as number;
 
     await firefox.setViewportSize(1200, 900);
     await waitForPageLoad(200);
 
-    const largeWidth = (await firefox.evaluate('return window.innerWidth')) as number;
-    const largeHeight = (await firefox.evaluate('return window.innerHeight')) as number;
+    const largeWidth = (await firefox.evaluate('window.innerWidth')) as number;
+    const largeHeight = (await firefox.evaluate('window.innerHeight')) as number;
 
     // Viewport should have grown in both dimensions
     expect(largeWidth).toBeGreaterThan(smallWidth);
@@ -416,10 +412,10 @@ describe('E2E Scenario: Form Submission', () => {
       { uid: emailInput!.uid, value: 'julian@mozilla.com' },
     ]);
 
-    const nameValue = await firefox.evaluate('return document.getElementById("regName").value');
+    const nameValue = await firefox.evaluate('document.getElementById("regName").value');
     expect(nameValue).toBe('Julian Descottes');
 
-    const emailValue = await firefox.evaluate('return document.getElementById("regEmail").value');
+    const emailValue = await firefox.evaluate('document.getElementById("regEmail").value');
     expect(emailValue).toBe('julian@mozilla.com');
   }, 20000);
 });

--- a/tests/tools/pages.test.ts
+++ b/tests/tools/pages.test.ts
@@ -2,13 +2,17 @@
  * Unit tests for pages tools
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import {
   listPagesTool,
   selectPageTool,
   navigatePageTool,
   newPageTool,
   closePageTool,
+  getPageTextTool,
 } from '../../src/tools/pages.js';
 
 describe('Pages Tools', () => {
@@ -65,6 +69,83 @@ describe('Pages Tools', () => {
       expect(properties).toBeDefined();
       expect(properties?.pageIdx).toBeDefined();
       expect(required).toContain('pageIdx');
+    });
+  });
+
+  describe('Content Tools', () => {
+    it('should have correct tool name', () => {
+      expect(getPageTextTool.name).toBe('get_page_text');
+    });
+
+    it('should expose maxLength, saveTo, and preview without marking them required', () => {
+      const schema = getPageTextTool.inputSchema as {
+        properties?: Record<string, unknown>;
+        required?: string[];
+      };
+      expect(schema.properties?.maxLength).toBeDefined();
+      expect(schema.properties?.saveTo).toBeDefined();
+      expect(schema.properties?.preview).toBeDefined();
+      expect(schema.required).toBeUndefined();
+    });
+  });
+
+  describe('Content Tools: handler behavior', () => {
+    const LONG_TEXT = 'y'.repeat(30000);
+    let tempDir: string;
+
+    beforeEach(() => {
+      tempDir = join(tmpdir(), `pages-test-${Date.now()}`);
+
+      vi.doMock('../../src/index.js', () => ({
+        args: { unrestrictedSavePaths: true },
+        getFirefox: vi.fn().mockResolvedValue({
+          evaluate: vi.fn().mockResolvedValue(LONG_TEXT),
+        }),
+      }));
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+      if (existsSync(tempDir)) {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should truncate inline output to maxLength with an escape-hatch footer', async () => {
+      const { handleGetPageText } = await import('../../src/tools/pages.js');
+      const result = await handleGetPageText({ maxLength: 100 });
+
+      const text = (result.content[0] as { type: 'text'; text: string }).text;
+      expect(text).toContain('chars hidden');
+      expect(text).toContain('saveTo');
+      expect(text.length).toBeLessThan(LONG_TEXT.length);
+    });
+
+    it('should return content inline with a completeness marker when it fits maxLength', async () => {
+      const { handleGetPageText } = await import('../../src/tools/pages.js');
+      const result = await handleGetPageText({ maxLength: LONG_TEXT.length });
+
+      const text = (result.content[0] as { type: 'text'; text: string }).text;
+      expect(text).toContain(LONG_TEXT);
+      expect(text).toContain(`[full content, ${LONG_TEXT.length} chars]`);
+    });
+
+    it('should save the full text untruncated when saveTo is used', async () => {
+      const { handleGetPageText } = await import('../../src/tools/pages.js');
+      const filePath = join(tempDir, 'page.txt');
+      const result = await handleGetPageText({ saveTo: filePath, maxLength: 100 });
+
+      const text = (result.content[0] as { type: 'text'; text: string }).text;
+      expect(text).toContain('saved to:');
+      expect(readFileSync(filePath, 'utf8')).toBe(LONG_TEXT);
+    });
+
+    it('should include a preview when preview is given', async () => {
+      const { handleGetPageText } = await import('../../src/tools/pages.js');
+      const result = await handleGetPageText({ saveTo: join(tempDir, 'page.txt'), preview: 100 });
+
+      const text = (result.content[0] as { type: 'text'; text: string }).text;
+      expect(text).toContain('Preview:');
     });
   });
 });


### PR DESCRIPTION
This tool allows to retrieve the page text directly. Before that, asking an agent to summarize or explore a page would usually first start taking a snapshot, and then resort to script evaluation to get the text.

Testing against Claude code, it seems to pickup the get_page_text tool very easily when it needs to get information from the page.