### PR TITLE
Bug 2055947 - [firefox-devtools-mcp] Allow to retrieve response body content

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -211,6 +211,13 @@ export const cliOptions = {
       'Allow tools that save files (e.g. screenshots, snapshots, network/console output) to write to arbitrary locations. By default, relative save paths resolve against the current working directory and absolute save paths are restricted to ~/.firefox-devtools-mcp; this flag lifts both restrictions. Use with caution.',
     default: (process.env.UNRESTRICTED_SAVE_PATHS ?? 'false') === 'true',
   },
+  disableNetworkBodyCollection: {
+    type: 'boolean',
+    hidden: true,
+    description:
+      'Disable capturing network request/response bodies via BiDi data collectors. get_network_request will still return metadata and headers but no bodies. Reduces browser memory and stream-cloning overhead.',
+    default: (process.env.DISABLE_NETWORK_BODY_COLLECTION ?? 'false') === 'true',
+  },
 } satisfies Record<string, YargsOptions>;
 
 export function parseArguments(version: string, argv = process.argv, includePrivileged = true) {

--- a/src/firefox/events/network.ts
+++ b/src/firefox/events/network.ts
@@ -9,6 +9,10 @@ import { logDebug } from '../../utils/logger.js';
 const MAX_NETWORK_REQUESTS = 1000; // Maximum number of requests to keep
 const NETWORK_TTL_MS = 5 * 60 * 1000; // 5 minutes TTL for old requests
 
+// Per-body cap for the BiDi data collector. Bodies larger than this are not
+// retained (Firefox also enforces a shared session-wide budget with eviction).
+const MAX_ENCODED_DATA_SIZE = 10 * 1000 * 1000; // 10 MB
+
 export interface NetworkEventsOptions {
   /** Callback triggered on navigation events (for auto-clear) */
   onNavigate?: () => void;
@@ -16,16 +20,25 @@ export interface NetworkEventsOptions {
   autoClearOnNavigate?: boolean;
 }
 
+/** Outcome of fetching a request/response body via the BiDi data collector. */
+export type NetworkBodyResult =
+  | { ok: true; type: 'base64' | 'string'; value: string }
+  | { ok: false; reason: 'unsupported' | 'not-collected' | 'evicted' | 'aborted' | 'error' };
+
+type SendBiDiCommand = (method: string, params?: Record<string, any>) => Promise<any>;
+
 export class NetworkEvents {
   private networkRecords: Map<string, any> = new Map();
   private subscribed = false;
   private enabled = false;
   private requestStartTimes: Map<string, number> = new Map();
   private options: NetworkEventsOptions;
+  private collectorId: string | null = null;
 
   constructor(
     private driver: WebDriver,
-    options: NetworkEventsOptions = {}
+    options: NetworkEventsOptions = {},
+    private sendCommand?: SendBiDiCommand
   ) {
     this.options = {
       autoClearOnNavigate: true,
@@ -158,10 +171,83 @@ export class NetworkEvents {
       }
     });
 
+    // Register a data collector so response (and request) bodies are captured
+    // and can be fetched on demand via fetchBody(). Best-effort: older Firefox
+    // versions without this command degrade to metadata-only network records.
+    await this.registerDataCollector();
+
     this.subscribed = true;
     // Enable monitoring by default (always-on)
     this.enabled = true;
     logDebug('Network listener ready with lifecycle hooks (monitoring enabled by default)');
+  }
+
+  /**
+   * Register a BiDi network data collector for request and response bodies.
+   * Failures are non-fatal and simply leave body capture disabled.
+   */
+  private async registerDataCollector(): Promise<void> {
+    if (!this.sendCommand) {
+      return;
+    }
+
+    try {
+      const result = await this.sendCommand('network.addDataCollector', {
+        dataTypes: ['request', 'response'],
+        maxEncodedDataSize: MAX_ENCODED_DATA_SIZE,
+      });
+      this.collectorId = result?.collector ?? null;
+      if (this.collectorId) {
+        logDebug(`Network data collector registered (${this.collectorId})`);
+      }
+    } catch (error) {
+      logDebug(
+        `Network data collector unavailable, response bodies will not be captured: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+  }
+
+  /**
+   * Fetch a captured request or response body via network.getData.
+   * Returns a structured result so callers can render an appropriate marker
+   * when the body was never collected, evicted, or the browser lacks support.
+   */
+  async fetchBody(requestId: string, dataType: 'request' | 'response'): Promise<NetworkBodyResult> {
+    if (!this.sendCommand || !this.collectorId) {
+      return { ok: false, reason: 'unsupported' };
+    }
+
+    try {
+      const result = await this.sendCommand('network.getData', {
+        request: requestId,
+        dataType,
+      });
+      const bytes = result?.bytes;
+      if (!bytes || typeof bytes.value !== 'string') {
+        return { ok: false, reason: 'not-collected' };
+      }
+      return {
+        ok: true,
+        type: bytes.type === 'base64' ? 'base64' : 'string',
+        value: bytes.value,
+      };
+    } catch (error) {
+      const message = (error instanceof Error ? error.message : String(error)).toLowerCase();
+      if (message.includes('no such network data')) {
+        return { ok: false, reason: 'not-collected' };
+      }
+      if (message.includes('unavailable network data')) {
+        if (message.includes('evicted')) {
+          return { ok: false, reason: 'evicted' };
+        }
+        if (message.includes('aborted')) {
+          return { ok: false, reason: 'aborted' };
+        }
+      }
+      return { ok: false, reason: 'error' };
+    }
   }
 
   /**

--- a/src/firefox/events/network.ts
+++ b/src/firefox/events/network.ts
@@ -18,6 +18,8 @@ export interface NetworkEventsOptions {
   onNavigate?: () => void;
   /** Auto-clear network requests on navigation (default: true when monitoring is enabled) */
   autoClearOnNavigate?: boolean;
+  /** Register a data collector so request/response bodies can be fetched (default: true) */
+  captureBodies?: boolean;
 }
 
 /** Outcome of fetching a request/response body via the BiDi data collector. */
@@ -171,12 +173,10 @@ export class NetworkEvents {
       }
     });
 
-    // Register a data collector so response (and request) bodies are captured
-    // and can be fetched on demand via fetchBody(). Best-effort: older Firefox
-    // versions without this command degrade to metadata-only network records.
     await this.registerDataCollector();
 
     this.subscribed = true;
+
     // Enable monitoring by default (always-on)
     this.enabled = true;
     logDebug('Network listener ready with lifecycle hooks (monitoring enabled by default)');
@@ -187,6 +187,11 @@ export class NetworkEvents {
    * Failures are non-fatal and simply leave body capture disabled.
    */
   private async registerDataCollector(): Promise<void> {
+    if (this.options.captureBodies === false) {
+      logDebug('Network body capture disabled, skipping data collector registration');
+      return;
+    }
+
     if (!this.sendCommand) {
       return;
     }
@@ -239,6 +244,8 @@ export class NetworkEvents {
         return { ok: false, reason: 'not-collected' };
       }
       if (message.includes('unavailable network data')) {
+        // reason for unavailable network data errors can be either evicted or
+        // aborted in Firefox (see https://searchfox.org/firefox-main/rev/d573d849c063353bda3a67541ab219c8a548773a/remote/webdriver-bidi/modules/root/network.sys.mjs#396-399)
         if (message.includes('evicted')) {
           return { ok: false, reason: 'evicted' };
         }

--- a/src/firefox/index.ts
+++ b/src/firefox/index.ts
@@ -8,6 +8,7 @@ import { FirefoxCore } from './core.js';
 import { logDebug } from '../utils/logger.js';
 import { remoteValueToNative } from '../utils/remote-value.js';
 import { ConsoleEvents, NetworkEvents, DebuggingEvents, DownloadEvents } from './events/index.js';
+import type { NetworkBodyResult } from './events/network.js';
 import { DomInteractions } from './dom.js';
 import { PageManagement } from './pages.js';
 import { SnapshotManager, type Snapshot, type SnapshotOptions } from './snapshot/index.js';
@@ -63,10 +64,14 @@ export class FirefoxClient {
         autoClearOnNavigate: false,
       });
 
-      this.networkEvents = new NetworkEvents(driver as any, {
-        onNavigate,
-        autoClearOnNavigate: false,
-      });
+      this.networkEvents = new NetworkEvents(
+        driver as any,
+        {
+          onNavigate,
+          autoClearOnNavigate: false,
+        },
+        (method, params) => this.core.sendBiDiCommand(method, params ?? {})
+      );
 
       this.debuggingEvents = new DebuggingEvents(driver as any, (method, params) =>
         this.core.sendBiDiCommand(method, params)
@@ -379,6 +384,22 @@ export class FirefoxClient {
       );
     }
     this.networkEvents.clearRequests();
+  }
+
+  /**
+   * Fetch a captured request or response body for a given request id.
+   * Returns a structured result describing the body or why it is unavailable.
+   */
+  async getNetworkRequestBody(
+    requestId: string,
+    dataType: 'request' | 'response'
+  ): Promise<NetworkBodyResult> {
+    if (!this.networkEvents) {
+      throw new Error(
+        'Network events not available (Firefox Remote Agent not running — start Firefox with --remote-debugging-port to enable BiDi)'
+      );
+    }
+    return this.networkEvents.fetchBody(requestId, dataType);
   }
 
   // ============================================================================

--- a/src/firefox/index.ts
+++ b/src/firefox/index.ts
@@ -69,6 +69,7 @@ export class FirefoxClient {
         {
           onNavigate,
           autoClearOnNavigate: false,
+          captureBodies: this.core.getOptions().captureNetworkBodies !== false,
         },
         (method, params) => this.core.sendBiDiCommand(method, params ?? {})
       );

--- a/src/firefox/types.ts
+++ b/src/firefox/types.ts
@@ -95,6 +95,8 @@ export interface FirefoxLaunchOptions {
   androidDevice?: string | undefined;
   /** Android app package name (default: org.mozilla.firefox) */
   androidPackage?: string | undefined;
+  /** Capture network request/response bodies via BiDi data collectors (default: true) */
+  captureNetworkBodies?: boolean | undefined;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,6 +131,7 @@ export async function getFirefox(): Promise<FirefoxDevTools> {
       prefs,
       androidDevice: args.androidDevice ?? undefined,
       androidPackage: args.androidPackage ?? undefined,
+      captureNetworkBodies: !args.disableNetworkBodyCollection,
     };
   }
 

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -8,12 +8,15 @@ import {
   errorResponse,
   jsonResponse,
   truncateHeaders,
+  truncateText,
   previewExcerpt,
   truncationFooter,
+  TOKEN_LIMITS,
 } from '../utils/response-helpers.js';
 import { saveOutput } from '../utils/save-output.js';
 import { defineModule } from './module.js';
 import type { McpToolResponse } from '../types/common.js';
+import type { NetworkBodyResult } from '../firefox/events/network.js';
 
 // Tool definitions
 export const listNetworkRequestsTool = {
@@ -93,7 +96,8 @@ export const listNetworkRequestsTool = {
 
 export const getNetworkRequestTool = {
   name: 'get_network_request',
-  description: 'Get request details by ID. URL lookup as fallback.',
+  description:
+    'Get request details by ID, including the response body (and request body when present). Large text bodies are truncated inline; binary bodies are summarized. URL lookup as fallback.',
   annotations: {
     readOnlyHint: true,
   },
@@ -116,7 +120,7 @@ export const getNetworkRequestTool = {
       saveTo: {
         type: ['boolean', 'string'],
         description:
-          'Save the request details with full untruncated headers to a file as JSON instead of returning them inline. Pass a file path, an existing directory (generated file inside), or true (generated file under ~/.firefox-devtools-mcp/output/). Relative paths resolve against the current working directory.',
+          'Save the request details with full untruncated headers and bodies to a file as JSON instead of returning them inline (binary bodies are stored base64-encoded). Pass a file path, an existing directory (generated file inside), or true (generated file under ~/.firefox-devtools-mcp/output/). Relative paths resolve against the current working directory.',
       },
       preview: {
         type: 'number',
@@ -126,6 +130,78 @@ export const getNetworkRequestTool = {
     },
   },
 };
+
+/**
+ * Fetch a body without letting a missing facade method or transport error fail
+ * the whole tool call. Absent support degrades to an 'unsupported' marker.
+ */
+async function safeFetchBody(
+  firefox: {
+    getNetworkRequestBody?: (
+      id: string,
+      dataType: 'request' | 'response'
+    ) => Promise<NetworkBodyResult>;
+  },
+  id: string,
+  dataType: 'request' | 'response'
+): Promise<NetworkBodyResult> {
+  if (typeof firefox.getNetworkRequestBody !== 'function') {
+    return { ok: false, reason: 'unsupported' };
+  }
+  try {
+    return await firefox.getNetworkRequestBody(id, dataType);
+  } catch {
+    return { ok: false, reason: 'error' };
+  }
+}
+
+function bodyUnavailableMarker(reason: string): string {
+  switch (reason) {
+    case 'unsupported':
+      return '<not captured: body collection not supported by this Firefox>';
+    case 'not-collected':
+      return '<not captured>';
+    case 'evicted':
+      return '<not available: evicted from the capture buffer>';
+    case 'aborted':
+      return '<not available: collection aborted>';
+    default:
+      return '<not available>';
+  }
+}
+
+/** A request body is only worth surfacing when it existed on the wire. */
+function hasRequestBody(result: NetworkBodyResult): boolean {
+  return result.ok || result.reason === 'evicted' || result.reason === 'aborted';
+}
+
+function renderBodyInline(result: NetworkBodyResult): { body: string; encoding?: 'base64' } {
+  if (!result.ok) {
+    return { body: bodyUnavailableMarker(result.reason) };
+  }
+  if (result.type === 'base64') {
+    const approxKb = ((result.value.length * 3) / 4 / 1024).toFixed(1);
+    return {
+      body: `<binary data (~${approxKb}KB); use saveTo to retrieve the full body>`,
+      encoding: 'base64',
+    };
+  }
+  return { body: truncateText(result.value, TOKEN_LIMITS.MAX_RESPONSE_CHARS) };
+}
+
+function renderBodyForFile(result: NetworkBodyResult): {
+  body: string | null;
+  encoding: 'base64' | 'utf-8' | null;
+  unavailable?: string;
+} {
+  if (!result.ok) {
+    return { body: null, encoding: null, unavailable: result.reason };
+  }
+  return {
+    body: result.value,
+    encoding: result.type === 'base64' ? 'base64' : 'utf-8',
+  };
+}
 
 // Tool handlers
 export async function handleListNetworkRequests(args: unknown): Promise<McpToolResponse> {
@@ -437,8 +513,31 @@ export async function handleGetNetworkRequest(args: unknown): Promise<McpToolRes
       responseHeaders: request.responseHeaders ?? null,
     };
 
+    const [responseBodyResult, requestBodyResult] = await Promise.all([
+      safeFetchBody(firefox, request.id, 'response'),
+      safeFetchBody(firefox, request.id, 'request'),
+    ]);
+
     if (saveTo) {
-      const fileBody = JSON.stringify(fullDetails, null, 2);
+      const responseFile = renderBodyForFile(responseBodyResult);
+      const fileObject: Record<string, unknown> = {
+        ...fullDetails,
+        responseBody: responseFile.body,
+        responseBodyEncoding: responseFile.encoding,
+      };
+      if (responseFile.unavailable) {
+        fileObject.responseBodyUnavailable = responseFile.unavailable;
+      }
+      if (hasRequestBody(requestBodyResult)) {
+        const requestFile = renderBodyForFile(requestBodyResult);
+        fileObject.requestBody = requestFile.body;
+        fileObject.requestBodyEncoding = requestFile.encoding;
+        if (requestFile.unavailable) {
+          fileObject.requestBodyUnavailable = requestFile.unavailable;
+        }
+      }
+
+      const fileBody = JSON.stringify(fileObject, null, 2);
       const saved = await saveOutput(
         fileBody,
         saveTo === true ? undefined : saveTo,
@@ -453,11 +552,23 @@ export async function handleGetNetworkRequest(args: unknown): Promise<McpToolRes
     }
 
     // Apply header truncation to prevent token overflow
-    const details = {
+    const responseInline = renderBodyInline(responseBodyResult);
+    const details: Record<string, unknown> = {
       ...fullDetails,
       requestHeaders: truncateHeaders(request.requestHeaders),
       responseHeaders: truncateHeaders(request.responseHeaders),
+      responseBody: responseInline.body,
     };
+    if (responseInline.encoding) {
+      details.responseBodyEncoding = responseInline.encoding;
+    }
+    if (hasRequestBody(requestBodyResult)) {
+      const requestInline = renderBodyInline(requestBodyResult);
+      details.requestBody = requestInline.body;
+      if (requestInline.encoding) {
+        details.requestBodyEncoding = requestInline.encoding;
+      }
+    }
 
     if (format === 'json') {
       return jsonResponse(details);

--- a/tests/tools/network.test.ts
+++ b/tests/tools/network.test.ts
@@ -199,4 +199,121 @@ describe('Network Tools', () => {
       expect(raw).not.toContain('...[truncated]');
     });
   });
+
+  describe('Handler: response bodies', () => {
+    const REQUESTS = [
+      {
+        id: 'r1',
+        url: 'https://example.test/data.json',
+        method: 'GET',
+        status: 200,
+        statusText: 'OK',
+        resourceType: 'xhr',
+        isXHR: true,
+        timestamp: 1700000000000,
+        timings: { duration: 12 },
+        requestHeaders: {},
+        responseHeaders: { 'content-type': 'application/json' },
+      },
+    ];
+
+    function mockFirefox(fetchBody: (id: string, dataType: string) => Promise<unknown>) {
+      vi.doMock('../../src/index.js', () => ({
+        args: { unrestrictedSavePaths: true },
+        getFirefox: vi.fn().mockResolvedValue({
+          getNetworkRequests: vi.fn().mockResolvedValue(REQUESTS),
+          getNetworkRequestBody: vi.fn(fetchBody),
+        }),
+      }));
+    }
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('should include a text response body inline', async () => {
+      mockFirefox(async (_id, dataType) =>
+        dataType === 'response'
+          ? { ok: true, type: 'string', value: '{"hello":"world"}' }
+          : { ok: false, reason: 'not-collected' }
+      );
+
+      const { handleGetNetworkRequest } = await import('../../src/tools/network.js');
+      const result = await handleGetNetworkRequest({ id: 'r1' });
+
+      expect(result.isError).toBeUndefined();
+      const parsed = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      expect(parsed.responseBody).toBe('{"hello":"world"}');
+      // GET with no request body: requestBody must be omitted, not shown as a marker.
+      expect(parsed).not.toHaveProperty('requestBody');
+    });
+
+    it('should summarize a binary response body instead of dumping base64', async () => {
+      mockFirefox(async (_id, dataType) =>
+        dataType === 'response'
+          ? { ok: true, type: 'base64', value: 'AAAA'.repeat(1000) }
+          : { ok: false, reason: 'not-collected' }
+      );
+
+      const { handleGetNetworkRequest } = await import('../../src/tools/network.js');
+      const result = await handleGetNetworkRequest({ id: 'r1' });
+
+      const parsed = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      expect(parsed.responseBody).toContain('binary data');
+      expect(parsed.responseBody).toContain('saveTo');
+      expect(parsed.responseBodyEncoding).toBe('base64');
+    });
+
+    it('should render a marker when the body was not captured', async () => {
+      mockFirefox(async () => ({ ok: false, reason: 'not-collected' }));
+
+      const { handleGetNetworkRequest } = await import('../../src/tools/network.js');
+      const result = await handleGetNetworkRequest({ id: 'r1' });
+
+      const parsed = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      expect(parsed.responseBody).toBe('<not captured>');
+    });
+
+    it('should degrade gracefully when body capture is unsupported', async () => {
+      vi.doMock('../../src/index.js', () => ({
+        args: { unrestrictedSavePaths: true },
+        getFirefox: vi.fn().mockResolvedValue({
+          getNetworkRequests: vi.fn().mockResolvedValue(REQUESTS),
+        }),
+      }));
+
+      const { handleGetNetworkRequest } = await import('../../src/tools/network.js');
+      const result = await handleGetNetworkRequest({ id: 'r1' });
+
+      expect(result.isError).toBeUndefined();
+      const parsed = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+      expect(parsed.responseBody).toContain('not supported');
+    });
+
+    it('should save the full untruncated body to a file', async () => {
+      const bigBody = 'x'.repeat(60_000);
+      mockFirefox(async (_id, dataType) =>
+        dataType === 'response'
+          ? { ok: true, type: 'string', value: bigBody }
+          : { ok: false, reason: 'not-collected' }
+      );
+
+      const tempDir = join(tmpdir(), `network-body-test-${Date.now()}`);
+      const filePath = join(tempDir, 'request.json');
+      try {
+        const { handleGetNetworkRequest } = await import('../../src/tools/network.js');
+        const result = await handleGetNetworkRequest({ id: 'r1', saveTo: filePath });
+
+        expect(result.isError).toBeUndefined();
+        const parsed = JSON.parse(readFileSync(filePath, 'utf8'));
+        expect(parsed.responseBody).toBe(bigBody);
+        expect(parsed.responseBody).not.toContain('truncated');
+        expect(parsed.responseBodyEncoding).toBe('utf-8');
+      } finally {
+        if (existsSync(tempDir)) {
+          rmSync(tempDir, { recursive: true, force: true });
+        }
+      }
+    });
+  });
 });


### PR DESCRIPTION
Automatically collect request and response bodies and attach them to network events.
Can be disabled with `--disableNetworkBodyCollection` / `--disable--network-body-collection` (hidden, meant as an escape hatch / debug option).