### PR TITLE
Bug 2059668 - Add sandbox option to evaluate_script

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Both flags are required because the MCP uses both WebDriver Classic (`--marionet
 - Downloads: list_downloads/clear_downloads (always‑on capture), set_download_behavior (allow/deny/default)
 - Console: list/clear (list supports optional `saveTo`)
 - Screenshot: page/by uid (with optional `saveTo` for CLI environments)
-- Script: evaluate_script (with optional `saveTo` for bulky results)
+- Script: evaluate_script (optional `sandbox` for an isolated realm; optional `saveTo` for bulky results)
 - Privileged Context: list/select privileged ("chrome") contexts, evaluate_privileged_script (requires `MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1`)
 - WebExtension: install_extension, uninstall_extension, list_extensions (list requires `MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1`)
 - Firefox Management: get_firefox_info, get_firefox_output, restart_firefox, set_firefox_prefs, get_firefox_prefs

--- a/src/tools/script.ts
+++ b/src/tools/script.ts
@@ -41,6 +41,11 @@ export const evaluateScriptTool = {
         type: 'number',
         description: 'Timeout in ms (default: 5000)',
       },
+      sandbox: {
+        type: 'string',
+        description:
+          'Evaluate in an isolated sandbox realm with this name instead of the page realm. The sandbox shares the page DOM but keeps the native built-ins even where the page overrode them, and its globals stay invisible to the page. The same name reuses the same sandbox across calls; omit to evaluate in the page realm.',
+      },
       saveTo: {
         type: ['boolean', 'string'],
         description:
@@ -72,12 +77,14 @@ export async function handleEvaluateScript(args: unknown): Promise<McpToolRespon
       function: fnString,
       args: fnArgs,
       timeout,
+      sandbox,
       saveTo,
       preview,
     } = args as {
       function: string;
       args?: Array<{ uid: string }>;
       timeout?: number;
+      sandbox?: string;
       saveTo?: boolean | string;
       preview?: number;
     };
@@ -123,7 +130,7 @@ export async function handleEvaluateScript(args: unknown): Promise<McpToolRespon
       functionDeclaration: fnString,
       awaitPromise: true,
       arguments: resolvedArgs,
-      target: { context: firefox.getCurrentContextId() },
+      target: { context: firefox.getCurrentContextId(), ...(sandbox !== undefined && { sandbox }) },
     });
 
     // Race against timeout as WebDriver BiDi callFunction has no built-in

--- a/src/tools/script.ts
+++ b/src/tools/script.ts
@@ -44,7 +44,7 @@ export const evaluateScriptTool = {
       sandbox: {
         type: 'string',
         description:
-          'Evaluate in an isolated sandbox realm with this name instead of the page realm. The sandbox shares the page DOM but keeps the native built-ins even where the page overrode them, and its globals stay invisible to the page. The same name reuses the same sandbox across calls; omit to evaluate in the page realm.',
+          'Evaluate in an isolated sandbox realm with this name instead of the page realm. The sandbox shares the page DOM and keeps the native built-ins even where the page overrode them. Page-defined globals and expandos are invisible from the sandbox, and vice-versa. The same name reuses the same sandbox across calls; omit to evaluate in the page realm.',
       },
       saveTo: {
         type: ['boolean', 'string'],

--- a/tests/tools/script.test.ts
+++ b/tests/tools/script.test.ts
@@ -51,6 +51,13 @@ describe('Script Tools', () => {
       expect(properties?.timeout.type).toBe('number');
     });
 
+    it('should have optional sandbox parameter', () => {
+      const { properties, required } = evaluateScriptTool.inputSchema;
+      expect(properties?.sandbox).toBeDefined();
+      expect(properties?.sandbox.type).toBe('string');
+      expect(required).not.toContain('sandbox');
+    });
+
     it('should have optional saveTo parameter', () => {
       const { properties, required } = evaluateScriptTool.inputSchema;
       expect(properties?.saveTo).toBeDefined();
@@ -178,6 +185,52 @@ describe('Script Tools', () => {
       const text = (result.content[0] as { type: 'text'; text: string }).text;
       expect(text).toContain('Script ran on page and returned:');
       expect(text).toContain(RESULT_VALUE);
+    });
+  });
+
+  describe('Handler: sandbox target', () => {
+    const sendBiDiCommand = vi.fn();
+
+    beforeEach(() => {
+      vi.resetModules();
+      sendBiDiCommand.mockReset();
+      sendBiDiCommand.mockResolvedValue({
+        type: 'success',
+        result: { type: 'number', value: 1 },
+      });
+
+      vi.doMock('../../src/index.js', () => ({
+        getFirefox: vi.fn().mockResolvedValue({
+          getCurrentContextId: vi.fn().mockReturnValue('ctx-1'),
+          sendBiDiCommand,
+        }),
+      }));
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('should target the page realm when sandbox is not given', async () => {
+      const { handleEvaluateScript } = await import('../../src/tools/script.js');
+      const result = await handleEvaluateScript({ function: '() => 1' });
+
+      expect(result.isError).toBeUndefined();
+      expect(sendBiDiCommand).toHaveBeenCalledWith(
+        'script.callFunction',
+        expect.objectContaining({ target: { context: 'ctx-1' } })
+      );
+    });
+
+    it('should pass the sandbox name in the target when given', async () => {
+      const { handleEvaluateScript } = await import('../../src/tools/script.js');
+      const result = await handleEvaluateScript({ function: '() => 1', sandbox: 'inspector' });
+
+      expect(result.isError).toBeUndefined();
+      expect(sendBiDiCommand).toHaveBeenCalledWith(
+        'script.callFunction',
+        expect.objectContaining({ target: { context: 'ctx-1', sandbox: 'inspector' } })
+      );
     });
   });
 });


### PR DESCRIPTION
Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=2059668

evaluate_script always runs in the page's own realm, so inspection is
filtered through whatever the page has overwritten (querySelector, getters,
Array.prototype methods) and anything the function leaves on the global
leaks into the page (details and motivation in the bug).

Implements the proposal from the bug: an optional sandbox string parameter
on evaluate_script, passed through to the BiDi target. The sandbox realm
shares the page DOM behind Xray wrappers with the page's own principal, so
built-ins stay native and writes stay invisible to the page. The same name
reuses the realm across calls; different names are isolated. Element UIDs
passed via args keep working. Without the parameter, the request and
response are identical to before.

Unit tests cover the schema and the BiDi target with and without sandbox.
