### PR TITLE
Bug 2059703 - Make evaluate_privileged_script target an explicit privileged context

### DIFF
--- a/src/tools/privileged-context.ts
+++ b/src/tools/privileged-context.ts
@@ -49,7 +49,7 @@ export const selectPrivilegedContextTool = {
 export const evaluatePrivilegedScriptTool = {
   name: 'evaluate_privileged_script',
   description:
-    'Execute JS function in the current privileged context. Requires MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1 env var. Use select_privileged_context first to target a chrome context.',
+    'Execute JS function in a privileged (chrome) browsing context. Requires MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1 env var. Get context ids from list_privileged_contexts.',
   annotations: {
     readOnlyHint: false,
   },
@@ -59,6 +59,10 @@ export const evaluatePrivilegedScriptTool = {
       function: {
         type: 'string',
         description: 'JS function string, e.g. () => Services.prefs.getBoolPref("foo")',
+      },
+      context: {
+        type: 'string',
+        description: 'Privileged browsing context ID from list_privileged_contexts',
       },
       saveTo: {
         type: ['boolean', 'string'],
@@ -71,7 +75,7 @@ export const evaluatePrivilegedScriptTool = {
           'Number of characters of the saved result to return inline as a preview when saveTo is used. Omit for no preview.',
       },
     },
-    required: ['function'],
+    required: ['function', 'context'],
   },
 };
 
@@ -90,6 +94,31 @@ function formatContextList(contexts: any[]): string {
   return lines.join('\n');
 }
 
+const SYSTEM_ACCESS_ERROR =
+  'Privileged context access not enabled. Set MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1 environment variable and restart Firefox.';
+
+// Top-level entries of the chrome-scoped tree are the privileged contexts;
+// their children are content tabs and must not be accepted.
+async function assertPrivilegedContext(firefox: any, contextId: string): Promise<void> {
+  let result;
+  try {
+    result = await firefox.sendBiDiCommand('browsingContext.getTree', {
+      'moz:scope': 'chrome',
+    });
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('UnsupportedOperationError')) {
+      throw new Error(SYSTEM_ACCESS_ERROR);
+    }
+    throw error;
+  }
+  const contexts: any[] = result.contexts || [];
+  if (!contexts.some((ctx) => ctx.context === contextId)) {
+    throw new Error(
+      `${contextId} is not a privileged context. Use list_privileged_contexts to see valid ids.`
+    );
+  }
+}
+
 export async function handleListPrivilegedContexts(_args: unknown): Promise<McpToolResponse> {
   try {
     const { getFirefox } = await import('../index.js');
@@ -104,11 +133,7 @@ export async function handleListPrivilegedContexts(_args: unknown): Promise<McpT
     return successResponse(formatContextList(contexts));
   } catch (error) {
     if (error instanceof Error && error.message.includes('UnsupportedOperationError')) {
-      return errorResponse(
-        new Error(
-          'Privileged context access not enabled. Set MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1 environment variable and restart Firefox.'
-        )
-      );
+      return errorResponse(new Error(SYSTEM_ACCESS_ERROR));
     }
     return errorResponse(error as Error);
   }
@@ -124,6 +149,8 @@ export async function handleSelectPrivilegedContext(args: unknown): Promise<McpT
 
     const { getFirefox } = await import('../index.js');
     const firefox = await getFirefox();
+
+    await assertPrivilegedContext(firefox, contextId);
 
     const driver = firefox.getDriver();
     await driver.switchTo().window(contextId);
@@ -159,24 +186,32 @@ export async function handleEvaluatePrivilegedScript(args: unknown): Promise<Mcp
   try {
     const {
       function: fnString,
+      context,
       saveTo,
       preview,
     } = args as {
       function: string;
+      context: string;
       saveTo?: boolean | string;
       preview?: number;
     };
 
     validateFunction(fnString);
 
+    if (!context || typeof context !== 'string') {
+      throw new Error('context parameter is required and must be a string');
+    }
+
     const { getFirefox } = await import('../index.js');
     const firefox = await getFirefox();
+
+    await assertPrivilegedContext(firefox, context);
 
     const result = await firefox.sendBiDiCommand('script.callFunction', {
       functionDeclaration: fnString,
       awaitPromise: true,
       arguments: [],
-      target: { context: firefox.getCurrentContextId() },
+      target: { context },
     });
 
     if (result.type === EvaluateResultType.Success) {

--- a/tests/tools/privileged-context.test.ts
+++ b/tests/tools/privileged-context.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   evaluatePrivilegedScriptTool,
   handleEvaluatePrivilegedScript,
+  handleSelectPrivilegedContext,
 } from '../../src/tools/privileged-context.js';
 
 // Mock the index module (used by handler tests)
@@ -11,6 +12,28 @@ vi.mock('../../src/index.js', () => ({
   getFirefox: () => mockGetFirefox(),
 }));
 
+// Chrome-scoped tree as returned by browsingContext.getTree: the chrome window
+// is top-level, content tabs are its children.
+const CHROME_TREE = {
+  contexts: [
+    {
+      context: 'chrome-1',
+      url: 'chrome://browser/content/browser.xhtml',
+      children: [{ context: 'tab-1', url: 'https://example.com/', children: [] }],
+    },
+  ],
+};
+
+function mockFirefoxForEval(callFunctionResult: unknown) {
+  return {
+    sendBiDiCommand: vi.fn((method: string) =>
+      method === 'browsingContext.getTree'
+        ? Promise.resolve(CHROME_TREE)
+        : Promise.resolve(callFunctionResult)
+    ),
+  };
+}
+
 describe('Privileged Context Tool Definitions', () => {
   describe('evaluatePrivilegedScriptTool', () => {
     it('should have correct name', () => {
@@ -19,6 +42,13 @@ describe('Privileged Context Tool Definitions', () => {
 
     it('should require function parameter', () => {
       expect(evaluatePrivilegedScriptTool.inputSchema.required).toContain('function');
+    });
+
+    it('should require context parameter', () => {
+      const { properties, required } = evaluatePrivilegedScriptTool.inputSchema;
+      expect(properties?.context).toBeDefined();
+      expect(properties?.context.type).toBe('string');
+      expect(required).toContain('context');
     });
 
     it('should have optional saveTo parameter of type boolean|string', () => {
@@ -57,46 +87,141 @@ describe('Privileged Context Tool Handlers', () => {
       expect(result.content[0].text).toContain('Invalid function format');
     });
 
-    it('should execute valid function successfully', async () => {
-      const mockFirefox = {
-        getCurrentContextId: vi.fn().mockReturnValue('context-1'),
-        sendBiDiCommand: vi.fn().mockResolvedValue({
-          type: 'success',
-          result: { type: 'string', value: 'test-result' },
-        }),
-      };
+    it('should execute valid function in the given privileged context', async () => {
+      const mockFirefox = mockFirefoxForEval({
+        type: 'success',
+        result: { type: 'string', value: 'test-result' },
+      });
 
       mockGetFirefox.mockResolvedValue(mockFirefox);
 
       const result = await handleEvaluatePrivilegedScript({
         function: '() => Services.prefs.getBoolPref("foo")',
+        context: 'chrome-1',
       });
 
       expect(result.isError).toBeUndefined();
       expect(result.content[0].text).toContain('chrome context');
       expect(result.content[0].text).toContain('test-result');
+      expect(mockFirefox.sendBiDiCommand).toHaveBeenCalledWith(
+        'script.callFunction',
+        expect.objectContaining({ target: { context: 'chrome-1' } })
+      );
     });
 
     it('should surface BiDi exception details', async () => {
-      const mockFirefox = {
-        getCurrentContextId: vi.fn().mockReturnValue('context-1'),
-        sendBiDiCommand: vi.fn().mockResolvedValue({
-          type: 'exception',
-          exceptionDetails: {
-            text: 'ReferenceError: Services is not defined',
-            exception: { type: 'object', value: [] },
-          },
-        }),
-      };
+      const mockFirefox = mockFirefoxForEval({
+        type: 'exception',
+        exceptionDetails: {
+          text: 'ReferenceError: Services is not defined',
+          exception: { type: 'object', value: [] },
+        },
+      });
 
       mockGetFirefox.mockResolvedValue(mockFirefox);
 
       const result = await handleEvaluatePrivilegedScript({
         function: '() => Services.prefs.getBoolPref("foo")',
+        context: 'chrome-1',
       });
 
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain('Services is not defined');
+    });
+
+    it('should return error when context parameter is missing', async () => {
+      const result = await handleEvaluatePrivilegedScript({ function: '() => 1' });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('context parameter is required');
+    });
+
+    it('should reject a content context id without evaluating', async () => {
+      const mockFirefox = mockFirefoxForEval({});
+      mockGetFirefox.mockResolvedValue(mockFirefox);
+
+      const result = await handleEvaluatePrivilegedScript({
+        function: '() => 1',
+        context: 'tab-1',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('not a privileged context');
+      expect(mockFirefox.sendBiDiCommand).not.toHaveBeenCalledWith(
+        'script.callFunction',
+        expect.anything()
+      );
+    });
+
+    it('should reject an unknown context id', async () => {
+      const mockFirefox = mockFirefoxForEval({});
+      mockGetFirefox.mockResolvedValue(mockFirefox);
+
+      const result = await handleEvaluatePrivilegedScript({
+        function: '() => 1',
+        context: 'no-such-context',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('not a privileged context');
+    });
+
+    it('should explain when system access is not enabled', async () => {
+      const mockFirefox = {
+        sendBiDiCommand: vi
+          .fn()
+          .mockRejectedValue(new Error('UnsupportedOperationError: not available')),
+      };
+      mockGetFirefox.mockResolvedValue(mockFirefox);
+
+      const result = await handleEvaluatePrivilegedScript({
+        function: '() => 1',
+        context: 'chrome-1',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('MOZ_REMOTE_ALLOW_SYSTEM_ACCESS');
+    });
+  });
+
+  describe('handleSelectPrivilegedContext', () => {
+    it('should switch to a privileged context', async () => {
+      const switchWindow = vi.fn().mockResolvedValue(undefined);
+      const mockFirefox = {
+        sendBiDiCommand: vi.fn().mockResolvedValue(CHROME_TREE),
+        setCurrentContextId: vi.fn(),
+        getDriver: () => ({
+          switchTo: () => ({ window: switchWindow }),
+          setContext: vi.fn().mockResolvedValue(undefined),
+        }),
+      };
+      mockGetFirefox.mockResolvedValue(mockFirefox);
+
+      const result = await handleSelectPrivilegedContext({ contextId: 'chrome-1' });
+
+      expect(result.isError).toBeUndefined();
+      expect(switchWindow).toHaveBeenCalledWith('chrome-1');
+      expect(mockFirefox.setCurrentContextId).toHaveBeenCalledWith('chrome-1');
+    });
+
+    it('should reject a content context id without switching', async () => {
+      const switchWindow = vi.fn().mockResolvedValue(undefined);
+      const mockFirefox = {
+        sendBiDiCommand: vi.fn().mockResolvedValue(CHROME_TREE),
+        setCurrentContextId: vi.fn(),
+        getDriver: () => ({
+          switchTo: () => ({ window: switchWindow }),
+          setContext: vi.fn().mockResolvedValue(undefined),
+        }),
+      };
+      mockGetFirefox.mockResolvedValue(mockFirefox);
+
+      const result = await handleSelectPrivilegedContext({ contextId: 'tab-1' });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('not a privileged context');
+      expect(switchWindow).not.toHaveBeenCalled();
+      expect(mockFirefox.setCurrentContextId).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=2059703

evaluate_privileged_script targets the shared "current tab" context id, which
select_page, new_page, and close_page overwrite, so after any tab operation a
privileged eval silently runs in the content page with the page's principal
while still reporting "Script ran in chrome context" (details and history in
the bug).

This makes the target explicit and validated: evaluate_privileged_script now
requires a context parameter, checked against the chrome-scoped
browsingContext.getTree before evaluating - only top-level entries qualify,
since a chrome window's children are content tabs. Invalid or missing targets
fail loudly instead of falling back to whatever tab is current.
select_privileged_context gets the same validation, so it no longer accepts
content ids while claiming a privileged switch. Its Marionette side
(setContext("chrome") and the shared-slot update that the prefs and extension
helpers rely on) is unchanged.

Requiring the parameter is a deliberate breaking change: an implicit default
would reintroduce the hidden state that caused the bug. Explicit per-call
targets are also what WebDriver BiDi itself uses - the protocol has no
current context - and the pattern stateful APIs keep converging on, from
HTTP's stateless requests to Selenium's switchTo() giving way to per-command
context ids in CDP and BiDi. Same direction as bug 2037070.

Unit tests cover the schema, per-call targeting, rejection of content and
unknown ids, the missing-parameter error, the system-access error path, and
select_privileged_context validation.
