### PR TITLE
fix: stop advertising the resources capability the server does not implement

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,8 +7,6 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
-  ListResourcesRequestSchema,
-  ReadResourceRequestSchema,
   CallToolRequest,
 } from '@modelcontextprotocol/sdk/types.js';
 
@@ -222,7 +220,6 @@ export async function run(
     },
     {
       capabilities: {
-        resources: {},
         tools: {},
       },
     }
@@ -265,16 +262,6 @@ export async function run(
       logError(`Error executing tool ${name}`, error);
       throw error;
     }
-  });
-
-  // List resources (not implemented for this server)
-  server.setRequestHandler(ListResourcesRequestSchema, async () => {
-    return { resources: [] };
-  });
-
-  // Read resource (not implemented for this server)
-  server.setRequestHandler(ReadResourceRequestSchema, async () => {
-    throw new Error('Resource reading not implemented');
   });
 
   const transport = new StdioServerTransport();


### PR DESCRIPTION
`src/index.ts` declares `capabilities.resources` at construction:

```ts
capabilities: {
  resources: {},
  tools: {},
},
```

but the server does not implement resources. Both handlers were stubs, and their own comments said as much:

```ts
// List resources (not implemented for this server)
server.setRequestHandler(ListResourcesRequestSchema, async () => {
  return { resources: [] };
});

// Read resource (not implemented for this server)
server.setRequestHandler(ReadResourceRequestSchema, async () => {
  throw new Error('Resource reading not implemented');
});
```

Declaring the capability is what makes this more than cosmetic: during `initialize` it tells every client that `resources/list` and `resources/read` are supported here. A capability-aware client will surface a resources affordance that is always empty, and any client that calls `resources/read` gets a plain `Error`, which the SDK reports as **`-32603` Internal error** — a code that means *the server broke*, not *this server has no resources*. That is a misleading thing to hand an agent.

This removes the declaration and the two stubs. Requests now fall through to **`-32601` Method not found**, which is the accurate answer for a method the server genuinely does not provide, and capability-aware clients stop routing resources requests here at all.

Verified locally against SDK 1.29.0:

```
BEFORE advertised capabilities = {"resources":{},"tools":{}}
AFTER  advertised capabilities = {"tools":{}}
```

```
npm run test:unit   41 files, 588 tests passed
npx tsc --noEmit    clean
npm run lint        clean
```

Nothing outside `src/index.ts` referenced resources — I grepped `src/` and `tests/` before removing the imports, so this is a pure deletion with no behavioural change for tools.

If you would rather keep the surface for a planned implementation, the alternative is to keep the handlers but throw `new McpError(ErrorCode.InvalidParams, ...)` from the read path so the error code stops implying a server fault. Happy to switch to that if it fits the roadmap better — I picked deletion because the comments read as "we don't do this," not "not yet."
