### PR TITLE
Bug 2060858 - [firefox-devtools-mcp] Add option to let MCP discover accessible Marionette ports

### DIFF
--- a/manifest.mcpb.json
+++ b/manifest.mcpb.json
@@ -21,7 +21,8 @@
       "command": "node",
       "args": [
         "${__dirname}/dist/index.js",
-        "--auto-profile",
+        "--connect-existing",
+        "--lookup-marionette-port",
         "--tool-preset",
         "developer",
         "--pref",

--- a/scripts/build-mcpb.mjs
+++ b/scripts/build-mcpb.mjs
@@ -13,7 +13,7 @@ import { tmpdir } from 'node:os';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const pkg = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8'));
-const manifest = JSON.parse(readFileSync(resolve(root, 'manifest.json'), 'utf8'));
+const manifest = JSON.parse(readFileSync(resolve(root, 'manifest.mcpb.json'), 'utf8'));
 
 console.log('Building server...');
 execSync('npm run build', { cwd: root, stdio: 'inherit' });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -136,6 +136,14 @@ export const cliOptions = {
     description: 'Marionette port to connect to when using --connect-existing (default: 2828)',
     default: Number(process.env.MARIONETTE_PORT ?? '2828'),
   },
+  lookupMarionettePort: {
+    type: 'boolean',
+    hidden: true,
+    description:
+      "Lookup the port of a Marionette instance started by Firefox's AI assistant " +
+      'companion, instead of using --marionette-port. Only applies when --connect-existing is set.',
+    default: (process.env.LOOKUP_MARIONETTE_PORT ?? 'false') === 'true',
+  },
   env: {
     type: 'array',
     description:

--- a/src/firefox/core.ts
+++ b/src/firefox/core.ts
@@ -4,7 +4,16 @@
 
 import { Builder, Browser, Capabilities, WebDriver } from 'selenium-webdriver';
 import firefox from 'selenium-webdriver/firefox.js';
-import { mkdirSync, openSync, closeSync, existsSync, readdirSync, statSync } from 'node:fs';
+import {
+  mkdirSync,
+  openSync,
+  closeSync,
+  existsSync,
+  readdirSync,
+  statSync,
+  readFileSync,
+} from 'node:fs';
+import { connect as netConnect } from 'node:net';
 import { homedir } from 'node:os';
 import { join, delimiter } from 'node:path';
 import type { FirefoxLaunchOptions } from './types.js';
@@ -60,6 +69,63 @@ async function findGeckodriverInNpmPackage(): Promise<string | null> {
   } catch {
     return null;
   }
+}
+
+function lookupMarionettePort(): number | void {
+  const instancesDir = join(homedir(), '.firefox-devtools-mcp', 'instances');
+  if (!existsSync(instancesDir)) {
+    logDebug(`Failed to lookup Marionette port: ${instancesDir} doesn't exist.`);
+    return;
+  }
+  const files = readdirSync(instancesDir);
+  const portFiles = files.filter((f) => /^\d+\.port$/.test(f));
+  const mostRecent = portFiles
+    .map((f) => ({
+      name: f,
+      path: join(instancesDir, f),
+      mtime: statSync(join(instancesDir, f)).mtimeMs,
+    }))
+    .sort((a, b) => b.mtime - a.mtime)[0];
+  if (mostRecent) {
+    const pid = Number(mostRecent.name.substring(0, mostRecent.name.length - 5));
+    if (!checkProcess(pid)) {
+      logDebug(`Failed to lookup Marionette port: No process with PID ${pid} is running.`);
+      return;
+    }
+    logDebug(`Reading Marionette port from ${mostRecent.path}`);
+    const content = readFileSync(mostRecent.path, 'utf-8').trim();
+    if (/^\d+$/.test(content)) {
+      return Number(content);
+    } else {
+      logDebug(`Failed to lookup Marionette port: "${content}" is not a number.`);
+    }
+  } else {
+    logDebug(`Failed to lookup Marionette port: No port file found in ${instancesDir}.`);
+  }
+}
+
+function checkProcess(pid: number): boolean {
+  try {
+    // this will only check for the process' existance but not kill it
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function checkPort(port: number, timeoutMs = 1000): Promise<string | null> {
+  return new Promise<string | null>((resolve) => {
+    const socket = netConnect({ host: '127.0.0.1', port });
+    const done = (reason: string | null) => {
+      socket.destroy();
+      resolve(reason);
+    };
+    socket.setTimeout(timeoutMs);
+    socket.once('connect', () => done(null));
+    socket.once('timeout', () => done(`connection to 127.0.0.1:${port} timed out`));
+    socket.once('error', (error: Error) => done(error.message));
+  });
 }
 
 /**
@@ -136,7 +202,37 @@ export class FirefoxCore {
       const serviceBuilder = new firefox.ServiceBuilder(geckodriverPath);
       this.driver = firefox.Driver.createSession(caps, serviceBuilder.build());
     } else if (this.options.connectExisting) {
-      const port = this.options.marionettePort ?? 2828;
+      let port = this.options.marionettePort ?? 2828;
+      if (this.options.lookupMarionettePort) {
+        logDebug('Looking up Marionette port');
+        const lookedUpPort = lookupMarionettePort();
+        if (lookedUpPort !== undefined) {
+          port = lookedUpPort;
+        } else {
+          throw new Error(
+            'Marionette port not found: please enable Firefox remote control for AI tooling using the AI assistant companion button.'
+          );
+        }
+      }
+      logDebug(`Using Marionette port ${port}`);
+
+      // Fail fast with an actionable message instead of letting geckodriver
+      // retry the connection for a minute and report a bare socket error.
+      const failure = await checkPort(port);
+      if (failure) {
+        if (this.options.lookupMarionettePort) {
+          throw new Error(
+            `No Marionette listener on 127.0.0.1:${port} (${failure}). ` +
+              'Please enable Firefox remote control for AI tooling using the AI assistant companion button.'
+          );
+        } else {
+          throw new Error(
+            `No Marionette listener on 127.0.0.1:${port} (${failure}). Start Firefox with ` +
+              'both flags: firefox --marionette --remote-debugging-port, or pass the port it ' +
+              'is actually using via --marionette-port.'
+          );
+        }
+      }
 
       const geckodriverPath = await findGeckodriver();
       logDebug(`Using geckodriver: ${geckodriverPath}`);

--- a/src/firefox/types.ts
+++ b/src/firefox/types.ts
@@ -87,6 +87,8 @@ export interface FirefoxLaunchOptions {
   acceptInsecureCerts?: boolean | undefined;
   connectExisting?: boolean | undefined;
   marionettePort?: number | undefined;
+  /** Lookup the Marionette port from Firefox's AI assistant companion instead of using marionettePort */
+  lookupMarionettePort?: boolean | undefined;
   env?: Record<string, string> | undefined;
   logFile?: string | undefined;
   /** Firefox preferences to set at startup via moz:firefoxOptions */

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,6 +124,7 @@ export async function getFirefox(): Promise<FirefoxDevTools> {
       acceptInsecureCerts: args.acceptInsecureCerts,
       connectExisting: args.connectExisting,
       marionettePort: args.marionettePort,
+      lookupMarionettePort: args.lookupMarionettePort,
       env: envVars,
       logFile: args.outputFile ?? undefined,
       prefs,

--- a/tests/firefox/connect-existing.test.ts
+++ b/tests/firefox/connect-existing.test.ts
@@ -56,6 +56,22 @@ describe('FirefoxCore connect() BiDi endpoint check', () => {
   const mockEnableBidi = vi.fn();
   const mockOptionsAddArguments = vi.fn();
 
+  // Fake socket for the Marionette port probe: emits `event` on the next tick.
+  const mockNetConnect = vi.fn();
+  const makeSocket = (event: 'connect' | 'timeout' | 'error', error?: Error) => {
+    const handlers = new Map<string, (arg?: unknown) => void>();
+    return {
+      setTimeout: vi.fn(),
+      destroy: vi.fn(),
+      once: vi.fn((name: string, handler: (arg?: unknown) => void) => {
+        handlers.set(name, handler);
+        if (name === event) {
+          setImmediate(() => handlers.get(event)?.(error));
+        }
+      }),
+    };
+  };
+
   // Builds a mock WebDriver whose getCapabilities() resolves to a
   // Capabilities-like object backed by the given values.
   const makeDriver = (capabilityValues: Record<string, unknown>) => ({
@@ -69,6 +85,9 @@ describe('FirefoxCore connect() BiDi endpoint check', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.resetModules();
+
+    mockNetConnect.mockReturnValue(makeSocket('connect'));
+    vi.doMock('node:net', () => ({ connect: mockNetConnect }));
 
     vi.doMock('selenium-webdriver/firefox.js', () => ({
       default: {
@@ -150,6 +169,41 @@ describe('FirefoxCore connect() BiDi endpoint check', () => {
     expect(mockCapabilitiesSet).toHaveBeenCalledWith('webSocketUrl', true);
     expect(core.getFirefoxVersion()).toBe('142.0');
     expect(core.getCurrentContextId()).toBe('mock-context-id');
+  });
+
+  it('should fail fast when nothing listens on the Marionette port', async () => {
+    mockNetConnect.mockReturnValue(
+      makeSocket('error', Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:2828')))
+    );
+
+    const { FirefoxCore } = await import('@/firefox/core.js');
+    const core = new FirefoxCore({ connectExisting: true, marionettePort: 2828 });
+
+    const connectPromise = core.connect();
+    await expect(connectPromise).rejects.toThrow(/No Marionette listener on 127\.0\.0\.1:2828/);
+    await expect(connectPromise).rejects.toThrow(/ECONNREFUSED/);
+
+    // geckodriver is never started, so no session is created
+    expect(mockCreateSession).not.toHaveBeenCalled();
+  });
+
+  it('should fail fast when the Marionette port does not respond', async () => {
+    mockNetConnect.mockReturnValue(makeSocket('timeout'));
+
+    const { FirefoxCore } = await import('@/firefox/core.js');
+    const core = new FirefoxCore({ connectExisting: true, marionettePort: 2828 });
+
+    await expect(core.connect()).rejects.toThrow(/timed out/);
+    expect(mockCreateSession).not.toHaveBeenCalled();
+  });
+
+  it('should not probe the Marionette port in launch mode', async () => {
+    const { FirefoxCore } = await import('@/firefox/core.js');
+    const core = new FirefoxCore({ headless: true });
+
+    await core.connect();
+
+    expect(mockNetConnect).not.toHaveBeenCalled();
   });
 
   it('should not apply the check in launch mode', async () => {


### PR DESCRIPTION
- adds a hidden option `--lookup-marionette-port` and reads the marionette port from the most recent `.port` file written to `~/.firefox-devtools-mcp/instances/`
- adds this option and `--connect-existing` to the MCPB `manifest.json`

I couldn't test this with the MCPB but I tested with the plugin by adding `--connect-existing` and `--lookup-marionette-port` to the `plugin.json` file.