### PR TITLE
docs: align preset and security docs with the actual tool registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Browser MCP servers carry inherent risks. A few key practices:
 
 - **Use a dedicated Firefox profile.** Never run the server against your regular profile — the agent has access to whatever the browser can reach, including cookies and saved sessions.
 - **Be cautious about which sites you visit.** Pages can return content designed to manipulate the agent (prompt injection). Stick to sites you control or trust.
-- **Enable only the tool modules you need.** Higher presets such as `--tool-preset developer` (script, debugging) and `--tool-preset mozilla` (privileged context) significantly expand what the agent can do.
+- **Enable only the tool modules you need.** The default `basic` preset already includes `evaluate_script`; `--tool-preset slim` drops it. Higher presets such as `--tool-preset developer` (debugging, network, console, profiler) and `--tool-preset mozilla` (privileged context) expand what the agent can do further.
 
 See [SECURITY.md](SECURITY.md) for a full breakdown of risks and how to report vulnerabilities.
 
@@ -138,6 +138,7 @@ You can pass flags or environment variables (names on the right):
 - `--enable-privileged-context` — _deprecated, use `--tool-preset mozilla` or `--tools ... privileged prefs`._  Selects the `mozilla` tool preset. Requires `MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1` (`ENABLE_PRIVILEGED_CONTEXT=true`)
 - `--android-device` — enable Firefox for Android mode; value is the ADB device serial (e.g. `emulator-5554`). Run `adb devices` to list connected devices. Omit the value or use `auto` to select the single connected device automatically.
 - `--android-package` — Android app package name, default `org.mozilla.firefox`. Other packages: `org.mozilla.firefox_beta` for Firefox Beta, `org.mozilla.fenix` for Firefox Nightly, `org.mozilla.fenix.debug` for Firefox Nightly Debug, `org.mozilla.geckoview_example` for geckoview (`ANDROID_PACKAGE`)
+- `--unrestricted-save-paths` — let the `saveTo` parameter write anywhere on disk instead of the default roots. See [Saving bulky output to disk](#saving-bulky-output-to-disk) and the security note in [SECURITY.md](SECURITY.md). (`UNRESTRICTED_SAVE_PATHS=true`)
 - `--log-file` — write MCP server logs to a file instead of stderr. Useful for debugging sessions with MCP clients that hide server output. Set `DEBUG=*` to also include verbose debug logs. Example: `--log-file /tmp/firefox-mcp.log`
 
 
@@ -147,20 +148,24 @@ Tools are grouped into modules. You choose which modules to expose either with a
 (`--tool-preset`) or with an explicit list (`--tools`). When both are given, `--tools` wins and
 the preset is ignored.
 
-Modules: `pages`, `snapshot`, `input`, `network`, `console`, `screenshot`, `utilities`,
-`management`, `webextension`, `profiler`, `screencast`, `script`, `debugging`, `prefs`,
-`privileged`.
+Modules: `pages`, `snapshot`, `input`, `network`, `console`, `screenshot`, `downloads`,
+`utilities`, `management`, `webextension`, `profiler`, `screencast`, `script`, `debugging`,
+`prefs`, `privileged`.
 
 Presets (each is a superset of the previous):
 
-- `slim` — `pages`, `snapshot`, `input`, `network`, `console`
-- `basic` (default) — `slim` plus `screenshot`, `utilities`, `management`, `webextension`, `profiler`, `screencast`
-- `developer` — `basic` plus `script`, `debugging`
+- `slim` — `pages`, `snapshot`, `input`, `screenshot`
+- `basic` (default) — `slim` plus `downloads`, `script`, `utilities`, `management`, `webextension`, `screencast`
+- `developer` — `basic` plus `debugging`, `network`, `console`, `profiler`
 - `mozilla` — `developer` plus `prefs`, `privileged`
 - `all` — every module
 
+Note that `basic`, the default, includes `script` and therefore the `evaluate_script` tool.
+See [SECURITY.md](SECURITY.md#tool-modules-and-presets) for what that means for the attack
+surface, and use `--tool-preset slim` or an explicit `--tools` list to drop it.
+
 ```bash
-# Use the developer preset (adds script and debugging tools)
+# Use the developer preset (adds network, console, debugging and profiler tools)
 npx @mozilla/firefox-devtools-mcp --tool-preset developer
 
 # Enable only the modules you need
@@ -168,7 +173,8 @@ npx @mozilla/firefox-devtools-mcp --tools pages network console
 ```
 
 The `prefs` and `privileged` modules require `MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1` and are only
-available in the Mozilla-internal build; the public package silently skips them even if requested.
+available in the Mozilla-internal build. The public package skips them even if requested and
+logs a warning naming the modules it dropped.
 
 ### Useful preferences (`--pref`)
 
@@ -228,7 +234,8 @@ Both flags are required because the MCP uses both WebDriver Classic (`--marionet
 - Script: evaluate_script (optional `sandbox` for an isolated realm; optional `saveTo` for bulky results)
 - Privileged Context: list/select privileged ("chrome") contexts, evaluate_privileged_script (requires `MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1`)
 - WebExtension: install_extension, uninstall_extension, list_extensions (list requires `MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1`)
-- Firefox Management: get_firefox_info, get_firefox_output, restart_firefox, set_firefox_prefs, get_firefox_prefs
+- Firefox Management: get_firefox_info, get_firefox_output, restart_firefox
+- Firefox Preferences: get_firefox_prefs, set_firefox_prefs (requires `MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1`)
 - Profiler: profiler_is_active, profiler_start (preset or explicit config), profiler_stop (saves profile to downloads directory)
 - Screencast: screencast_start (records the page viewport to a video file in the downloads directory), screencast_stop (requires Firefox 154+)
 - Utilities: accept/dismiss dialog, history back/forward, set viewport

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,24 +11,45 @@ Prompt injection is an attack where malicious content in the environment manipul
 This risk is inherent to any agent that reads web content. Mitigations:
 
 - Only visit pages whose content you control or trust.
-- Keep capabilities to the minimum needed (see **Risky Flags** below).
+- Keep capabilities to the minimum needed (see **Tool modules and presets** and **Risky Flags** below).
 - Use a dedicated profile with no sensitive data (see **Profile and Environment** below).
+
+## Tool modules and presets
+
+Tools are grouped into modules, selected with `--tool-preset` (a named group) or `--tools` (an explicit list). The preset you pick determines the agent's capabilities, so it is the main control over attack surface. See the [README](README.md#tool-modules-and-presets) for the full module list.
+
+| Preset | Adds | Notable capability |
+| --- | --- | --- |
+| `slim` | `pages`, `snapshot`, `input`, `screenshot` | Read and interact with pages |
+| `basic` (default) | `downloads`, `script`, `utilities`, `management`, `webextension`, `screencast` | **`evaluate_script`**, extension install, downloads |
+| `developer` | `debugging`, `network`, `console`, `profiler` | Request and response bodies, breakpoints |
+| `mozilla` | `prefs`, `privileged` | Privileged (chrome) context, Firefox preferences |
+
+> **Note:** `evaluate_script` is part of the default `basic` preset. It is included because agents commonly fall back to it when the higher-level tools cannot handle a page, but it also means the default configuration lets the agent run arbitrary JavaScript in any page context (see below). Use `--tool-preset slim`, or an explicit `--tools` list without `script`, when you do not want that.
+
+### `evaluate_script` (module `script`, enabled by default)
+
+Lets the agent execute arbitrary JavaScript in any page context. If the agent is compromised through prompt injection, an attacker can use this tool to exfiltrate page data, manipulate the DOM, or interact with browser APIs accessible to web content.
+
+### Privileged context tools (modules `privileged` and `prefs`)
+
+Tools that operate in Firefox's privileged (chrome) context: listing and selecting privileged contexts, evaluating privileged scripts, reading and writing Firefox preferences, and listing extensions. These tools require the `MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1` environment variable to be set, which is checked by the WebDriver implementation in Firefox to allow using any command that targets privileged contexts. They are only available in the Mozilla-internal build; the public package skips them even if requested.
+
+Unless you are developing or modifying Firefox itself, you likely do not need these modules. To set preferences at startup, you can always use the `--pref name=value` command-line argument instead. If you are missing commands or features to debug web content, please file a bug on [Bugzilla](https://bugzilla.mozilla.org/enter_bug.cgi?format=__default__&blocked=2026717&product=Developer%20Infrastructure&component=Firefox%20MCP) or reach out in the [#firefox-devtools-mcp Matrix room](https://chat.mozilla.org/#/room/#firefox-devtools-mcp:mozilla.org).
+
+> **Warning:** When the privileged modules are used together with `MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1`, the agent gains access to privileged Firefox APIs with no web-content sandbox boundary. Depending on what the agent does with that access, this can extend to operating-system–level actions. Only use this combination in fully isolated environments.
+
+The deprecated `--enable-script` and `--enable-privileged-context` flags select the `developer` and `mozilla` presets respectively. They still work, but `--tool-preset` and `--tools` describe what is actually enabled.
 
 ## Risky Flags
 
 The following flags expand the agent's capabilities and increase the attack surface. Do not enable them unless you have a specific need.
 
-### `--enable-script`
+### `--unrestricted-save-paths`
 
-Enables the `evaluate_script` tool, which lets the agent execute arbitrary JavaScript in any page context. If the agent is compromised through prompt injection, an attacker can use this tool to exfiltrate page data, manipulate the DOM, or interact with browser APIs accessible to web content.
+Tools that save output to disk (`take_snapshot`, `screenshot_page`, `list_network_requests`, `evaluate_script` and others via their `saveTo` parameter) are restricted by default: relative paths resolve against the current working directory, and absolute paths must stay within `~/.firefox-devtools-mcp`. This flag removes both restrictions, letting the agent write to any path the server process can reach.
 
-### `--enable-privileged-context`
-
-Enables tools that operate in Firefox's privileged (chrome) context: listing and selecting privileged contexts, evaluating privileged scripts, reading and writing Firefox preferences, and listing extensions. These tools require the `MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1` environment variable to be set, which is checked by the WebDriver implementation in Firefox to allow using any command that targets privileged contexts.
-
-Unless you are developing or modifying Firefox itself, you likely do not need this flag. To set preferences, you can always use the `--set-pref` command-line argument. If you are missing commands or features to debug web content, please file a bug on [Bugzilla](https://bugzilla.mozilla.org/enter_bug.cgi?format=__default__&blocked=2026717&product=Developer%20Infrastructure&component=Firefox%20MCP) or reach out in the [#firefox-devtools-mcp Matrix room](https://chat.mozilla.org/#/room/#firefox-devtools-mcp:mozilla.org).
-
-> **Warning:** When `--enable-privileged-context` is used together with `MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1`, the agent gains access to privileged Firefox APIs with no web-content sandbox boundary. Depending on what the agent does with that access, this can extend to operating-system–level actions. Only use this combination in fully isolated environments.
+Combined with prompt injection, this turns a page's content into arbitrary file writes with your user's privileges — for example overwriting a shell profile or a configuration file the agent is not otherwise meant to touch.
 
 ### `--connect-existing`
 
@@ -42,6 +63,6 @@ Disables TLS certificate validation, allowing the agent to visit sites with self
 
 **Use a dedicated profile.** Never point the MCP server at your regular Firefox profile. Create a clean, separate profile for automation. This limits the data the agent can access and prevents a compromised session from touching your personal browsing data.
 
-**Consider a sandboxed environment.** For automation that involves untrusted content, or when `--enable-privileged-context` is required, run Firefox inside an isolated environment (a container, VM, or dedicated OS user account), ideally with a network proxy to enforce outbound restrictions. This limits what an attacker can reach even if the agent is fully compromised.
+**Consider a sandboxed environment.** For automation that involves untrusted content, or when the privileged modules are required, run Firefox inside an isolated environment (a container, VM, or dedicated OS user account), ideally with a network proxy to enforce outbound restrictions. This limits what an attacker can reach even if the agent is fully compromised.
 
 **Claude sandbox does not cover MCP servers.** When using this server with Claude, Claude's process sandbox does not extend to MCP servers it starts — the MCP server process runs with your full user privileges. Users who want to restrict the server's OS-level access can explore Anthropic's [Sandbox Runtime](https://github.com/anthropic-experimental/sandbox-runtime) to apply a sandbox to MCP servers independently. The same approach may apply when using other AI agents.


### PR DESCRIPTION
## What I noticed

While reading through the tool registry I noticed README.md and SECURITY.md still describe the preset split from before b2e1887 ("fix: Update tool presets based on actual usage"). Every documented preset row is out of date, and one gap seems worth calling out on its own:

**SECURITY.md lists `--enable-script` under "Risky Flags" with "do not enable them unless you have a specific need", but `script` is now part of `basic`, and `basic` is `DEFAULT_PRESET`.** So someone who reads SECURITY.md and turns on no risky flags is still running with `evaluate_script` available, while the page tells them the opposite.

Two smaller things in the same area:

- `--unrestricted-save-paths` is not in "Risky Flags" at all, even though it lifts both save-path restrictions in `assertAllowedPath`.
- SECURITY.md points at `--set-pref`, which is not a real flag. The flag is `--pref name=value`.

## What I changed

Documentation only, no code.

**README.md**
- Corrected the preset table, the module list (`downloads` was missing) and the `--tool-preset developer` example.
- Added `--unrestricted-save-paths` to the CLI options list.
- Split the prefs tools out of the "Firefox Management" line, since `prefs` is a privileged module.
- Replaced "silently skips" with a note that `buildToolset` logs a warning naming the dropped modules.

**SECURITY.md**
- Added a "Tool modules and presets" section that describes capabilities per preset, since that is how the server is configured now. The deprecated flag names are still mentioned so people searching for them land in the right place.
- Documented that `evaluate_script` is in the default preset, with a pointer to `--tool-preset slim` for anyone who does not want it.
- Added `--unrestricted-save-paths` to "Risky Flags".
- Fixed `--set-pref` to `--pref name=value`.

## How I verified it

I printed the real preset composition from `src/tools/index.ts` and compared it line by line against the tables I wrote:

```
DEFAULT_PRESET = basic
slim       + pages, snapshot, input, screenshot
basic      + downloads, script, utilities, management, webextension, screencast
developer  + debugging, network, console, profiler
mozilla    + prefs, privileged
```

## What I deliberately left alone

Whether `script` belongs in `basic` is a product decision rather than a docs one, so I only wrote down the current behaviour. If you would rather move it back to `developer`, I am happy to do that instead and drop the matching parts of this PR.

I would also be glad to add a small test asserting the README preset list against `PRESETS`, along the lines of `tests/tools/registry.test.ts`, so this cannot drift again. Let me know if you want it here or as a follow-up.

Thanks for the reviews on my earlier patches.