### PR TITLE
Bug 2063831 - Require --android-wipe-app-data when connecting to Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ You can pass flags or environment variables (names on the right):
 - `--enable-script` — _deprecated, use `--tool-preset developer` or `--tools ... script debugging`._ Selects the `developer` tool preset. (`ENABLE_SCRIPT=true`)
 - `--enable-privileged-context` — _deprecated, use `--tool-preset mozilla` or `--tools ... privileged prefs`._  Selects the `mozilla` tool preset. Requires `MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1` (`ENABLE_PRIVILEGED_CONTEXT=true`)
 - `--android-device` — enable Firefox for Android mode; value is the ADB device serial (e.g. `emulator-5554`). Run `adb devices` to list connected devices. Omit the value or use `auto` to select the single connected device automatically.
+- `--android-wipe-app-data` — confirm that Android mode wipes all data of the target app. Required together with `--android-device`. (`ANDROID_WIPE_APP_DATA=true`)
 - `--android-package` — Android app package name, default `org.mozilla.firefox`. Other packages: `org.mozilla.firefox_beta` for Firefox Beta, `org.mozilla.fenix` for Firefox Nightly, `org.mozilla.fenix.debug` for Firefox Nightly Debug, `org.mozilla.geckoview_example` for geckoview (`ANDROID_PACKAGE`)
 - `--log-file` — write MCP server logs to a file instead of stderr. Useful for debugging sessions with MCP clients that hide server output. Set `DEBUG=*` to also include verbose debug logs. Example: `--log-file /tmp/firefox-mcp.log`
 
@@ -180,18 +181,27 @@ available in the Mozilla-internal build; the public package silently skips them 
 
 Use `--android-device` to automate Firefox running on an Android device. Requires `adb` on your PATH and geckodriver, which is managed automatically.
 
+> **Warning:** Android mode wipes all data of the target app before every session.
+> Tabs, history, bookmarks, passwords, cookies and settings are all lost. geckodriver runs
+> `adb shell pm clear <package>` when creating the session and offers no way to skip it,
+> then runs the session on its own temporary profile which is deleted afterwards.
+> Because of this, `--android-device` requires `--android-wipe-app-data`, and you should
+> install a build dedicated to automation rather than automating the browser you use.
+> [Bug 2064088](https://bugzilla.mozilla.org/show_bug.cgi?id=2064088) tracks adding an
+> option to geckodriver to keep the existing app data.
+
 ```bash
 # List connected devices
 adb devices
 
 # Launch Firefox for Android on the single connected device
-npx @mozilla/firefox-devtools-mcp --android-device auto
+npx @mozilla/firefox-devtools-mcp --android-device auto --android-wipe-app-data
 
 # Target a specific device
-npx @mozilla/firefox-devtools-mcp --android-device <serial>
+npx @mozilla/firefox-devtools-mcp --android-device <serial> --android-wipe-app-data
 
 # Use Firefox Nightly instead
-npx @mozilla/firefox-devtools-mcp --android-device <serial> --android-package org.mozilla.fenix
+npx @mozilla/firefox-devtools-mcp --android-device <serial> --android-package org.mozilla.fenix --android-wipe-app-data
 ```
 
 Port forwarding between the host and device is handled automatically by geckodriver.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -172,6 +172,13 @@ export const cliOptions = {
       'Android app package name (default: org.mozilla.firefox). Use org.mozilla.fenix for Nightly.',
     default: process.env.ANDROID_PACKAGE ?? 'org.mozilla.firefox',
   },
+  androidWipeAppData: {
+    type: 'boolean',
+    description:
+      'Confirm that connecting to Firefox for Android wipes all data of the target app (tabs, ' +
+      'history, bookmarks, passwords, settings). Required with --android-device.',
+    default: (process.env.ANDROID_WIPE_APP_DATA ?? 'false') === 'true',
+  },
   logFile: {
     type: 'string',
     description:

--- a/src/firefox/core.ts
+++ b/src/firefox/core.ts
@@ -166,9 +166,25 @@ export class FirefoxCore {
    */
   async connect(): Promise<void> {
     const isAndroid = this.options.androidDevice !== undefined;
+    const androidPackage = this.options.androidPackage ?? 'org.mozilla.firefox';
+
+    if (isAndroid && !this.options.androidWipeAppData) {
+      // geckodriver runs "adb shell pm clear <package>" before every Android session
+      // (AndroidHandler::prepare) and offers no way to opt out, so launching wipes the
+      // data of the target app instead of only using its own temporary profile.
+      // Bug 2064088 tracks adding an opt-out to geckodriver.
+      throw new Error(
+        `Firefox for Android mode wipes all data of ${androidPackage} ` +
+          'on the device: tabs, history, bookmarks, passwords, cookies and settings are all lost, ' +
+          'because geckodriver clears the app data before every session and cannot be configured to skip it. ' +
+          'Pass --android-wipe-app-data (or ANDROID_WIPE_APP_DATA=true) to confirm. ' +
+          'Prefer a build dedicated to automation, for instance --android-package org.mozilla.fenix for Nightly.'
+      );
+    }
 
     if (isAndroid) {
       log('Launching Firefox for Android via ADB...');
+      log(`Wiping all data of ${androidPackage} on the device`);
     } else if (this.options.connectExisting) {
       log('Connecting to existing Firefox via Marionette...');
     } else {
@@ -182,8 +198,7 @@ export class FirefoxCore {
       const geckodriverPath = await findGeckodriver();
       logDebug(`Using geckodriver: ${geckodriverPath}`);
 
-      const pkg = this.options.androidPackage ?? 'org.mozilla.firefox';
-      const mozOptions: Record<string, unknown> = { androidPackage: pkg };
+      const mozOptions: Record<string, unknown> = { androidPackage };
       const deviceSerial = this.options.androidDevice;
       if (deviceSerial && deviceSerial !== 'auto') {
         mozOptions.androidDeviceSerial = deviceSerial;

--- a/src/firefox/types.ts
+++ b/src/firefox/types.ts
@@ -97,6 +97,8 @@ export interface FirefoxLaunchOptions {
   androidDevice?: string | undefined;
   /** Android app package name (default: org.mozilla.firefox) */
   androidPackage?: string | undefined;
+  /** Acknowledge that Android mode wipes all data of the target app; required to launch on Android */
+  androidWipeAppData?: boolean | undefined;
   /** Capture network request/response bodies via BiDi data collectors (default: true) */
   captureNetworkBodies?: boolean | undefined;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,6 +130,7 @@ export async function getFirefox(): Promise<FirefoxDevTools> {
       prefs,
       androidDevice: args.androidDevice ?? undefined,
       androidPackage: args.androidPackage ?? undefined,
+      androidWipeAppData: args.androidWipeAppData,
       captureNetworkBodies: !args.disableNetworkBodyCollection,
     };
   }

--- a/tests/firefox/core.test.ts
+++ b/tests/firefox/core.test.ts
@@ -286,6 +286,25 @@ describe('FirefoxCore', () => {
   });
 });
 
+describe('FirefoxCore connect() Android app data wipe opt-in', () => {
+  it('should refuse to launch on Android without androidWipeAppData', async () => {
+    const core = new FirefoxCore({ androidDevice: 'auto' });
+
+    await expect(core.connect()).rejects.toThrow(
+      /wipes all data of org\.mozilla\.firefox.*--android-wipe-app-data/s
+    );
+  });
+
+  it('should name the target package in the error', async () => {
+    const core = new FirefoxCore({
+      androidDevice: 'emulator-5554',
+      androidPackage: 'org.mozilla.fenix',
+    });
+
+    await expect(core.connect()).rejects.toThrow(/wipes all data of org\.mozilla\.fenix/);
+  });
+});
+
 // Tests for connect() behavior with mocked Selenium
 describe('FirefoxCore connect() profile handling', () => {
   // Mock selenium-webdriver/firefox.js at module level


### PR DESCRIPTION
Until we can safely connect without wiping user data, update documentation and require an explicit flag to be passed when connecting to Android.