### PR TITLE
Bug 2064762 - [firefox-devtools-mcp] Advertise server instructions in the initialize response

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -190,6 +190,7 @@ export async function run(
     warnings,
     toolDefinitions: allTools,
     handlers: toolHandlers,
+    instructions,
   } = buildToolset({
     tools: args.tools,
     preset: args.toolPreset,
@@ -224,6 +225,7 @@ export async function run(
       capabilities: {
         tools: {},
       },
+      instructions,
     }
   );
 

--- a/src/tools/instructions.ts
+++ b/src/tools/instructions.ts
@@ -1,0 +1,52 @@
+/**
+ * Builds the `instructions` string sent in the initialize response. Clients
+ * deferring tool definitions load only tool names and this string upfront, and
+ * may truncate it, so keep it short and front-load the purpose.
+ */
+
+import { MODULES } from './index.js';
+
+const INSTRUCTIONS_INTRO = [
+  'Browse and debug the web with Firefox.',
+  'Use this for any browser or web page task: opening a URL, automating a web flow,',
+  'or debugging a page (console errors, network requests, DOM state).',
+  'The task does not need to name Firefox, reach for these tools unless another',
+  'browser is explicitly requested.',
+  'Chrome-only browser tools do not control Firefox, do not assume they cover this.',
+].join(' ');
+
+// Basic tools worth pushing towards the client in any case.
+const CORE_TOOLS = ['list_pages', 'new_page', 'navigate_page', 'take_snapshot', 'get_page_text'];
+
+// Additional tool suggestions for specific tasks.
+// Note: this does not have to cover all possible tools.
+const TASK_TOOLS: Array<{ purpose: string; tools: string[] }> = [
+  { purpose: 'interaction', tools: ['click_by_uid', 'fill_by_uid', 'hover_by_uid'] },
+  { purpose: 'debugging', tools: ['list_console_messages', 'list_network_requests'] },
+  { purpose: 'visuals', tools: ['screenshot_page', 'screenshot_by_uid'] },
+  { purpose: 'one-off JS', tools: ['evaluate_script'] },
+];
+
+export function buildInstructions(moduleNames: string[], toolNames: Set<string>): string {
+  const byName = new Map(MODULES.map((m) => [m.name, m]));
+  const capabilities = moduleNames.flatMap((name) => {
+    const module = byName.get(name);
+    return module ? [`- ${module.name}: ${module.description}`] : [];
+  });
+  const sections = [INSTRUCTIONS_INTRO, ['Enabled capabilities:', ...capabilities].join('\n')];
+
+  const core = CORE_TOOLS.filter((name) => toolNames.has(name));
+  if (core.length > 0) {
+    const groups = TASK_TOOLS.flatMap(({ purpose, tools }) => {
+      const available = tools.filter((name) => toolNames.has(name));
+      return available.length > 0 ? [`${available.join(' / ')} for ${purpose}`] : [];
+    });
+    const extra =
+      groups.length > 0 ? ` Add task-specific tools to the same search: ${groups.join(', ')}.` : '';
+    sections.push(
+      `When these tools are deferred, load the core set in one search rather than one at a time: ${core.join(', ')}.${extra}`
+    );
+  }
+
+  return sections.join('\n\n');
+}

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -4,10 +4,11 @@
  * Reads the module catalog (index.ts) and turns CLI configuration into the set
  * of tools to expose: buildToolset resolves which modules are enabled (applying
  * presets, deprecated flags, and the privileged gate) and builds the tool
- * definition list + name->handler map for them.
+ * definition list + name->handler map + server instructions for them.
  */
 
 import { MODULES, MODULE_NAMES, PRESETS, DEFAULT_PRESET } from './index.js';
+import { buildInstructions } from './instructions.js';
 import type { ToolDefinition, ToolHandler } from './module.js';
 
 export interface ToolsetOptions {
@@ -23,6 +24,7 @@ export interface Toolset {
   warnings: string[];
   toolDefinitions: ToolDefinition[];
   handlers: Map<string, ToolHandler>;
+  instructions: string;
 }
 
 const privilegedModuleNames = new Set(MODULES.filter((m) => m.privileged).map((m) => m.name));
@@ -37,7 +39,8 @@ const privilegedModuleNames = new Set(MODULES.filter((m) => m.privileged).map((m
 export function buildToolset(options: ToolsetOptions): Toolset {
   const { moduleNames, warnings } = selectModules(options);
   const { toolDefinitions, handlers } = collectTools(moduleNames);
-  return { moduleNames, warnings, toolDefinitions, handlers };
+  const instructions = buildInstructions(moduleNames, new Set(handlers.keys()));
+  return { moduleNames, warnings, toolDefinitions, handlers, instructions };
 }
 
 /**

--- a/tests/tools/instructions.test.ts
+++ b/tests/tools/instructions.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Unit tests for the server instructions sent in the initialize response.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { PRESETS } from '../../src/tools/index.js';
+import { buildToolset } from '../../src/tools/registry.js';
+
+describe('Server instructions', () => {
+  it('lists only the enabled modules', () => {
+    const { instructions } = buildToolset({ tools: ['pages', 'network'] });
+    expect(instructions).toContain('- pages: ');
+    expect(instructions).toContain('- network: ');
+    expect(instructions).not.toContain('- console: ');
+  });
+
+  it('only suggests loading tools which are enabled', () => {
+    const { instructions } = buildToolset({ tools: ['pages'] });
+    expect(instructions).toContain('list_pages');
+    expect(instructions).not.toContain('take_snapshot');
+    expect(instructions).not.toContain('list_console_messages');
+  });
+
+  it('never names a tool that does not exist (catches renames)', () => {
+    const { instructions, toolDefinitions } = buildToolset({
+      preset: 'all',
+      allowPrivileged: true,
+    });
+    const names = new Set(toolDefinitions.map((d) => d.name));
+    // Tool names are the only snake_case tokens in the instructions.
+    const mentioned = instructions.match(/\b[a-z]+(?:_[a-z]+)+\b/g) ?? [];
+    expect(mentioned.length).toBeGreaterThan(0);
+    expect(mentioned.filter((name) => !names.has(name))).toEqual([]);
+  });
+
+  it('stays within the size clients are willing to load', () => {
+    for (const preset of Object.keys(PRESETS)) {
+      const { instructions } = buildToolset({ preset, allowPrivileged: true });
+      expect(instructions.length).toBeLessThan(2048);
+    }
+  });
+});

--- a/tests/tools/registry.test.ts
+++ b/tests/tools/registry.test.ts
@@ -11,7 +11,7 @@ import type { ToolModule } from '../../src/tools/module.js';
 
 // Tool files whose exports are not modules; everything else in src/tools is
 // expected to declare a module via defineModule.
-const NON_MODULE_FILES = new Set(['index.ts', 'module.ts', 'registry.ts']);
+const NON_MODULE_FILES = new Set(['index.ts', 'instructions.ts', 'module.ts', 'registry.ts']);
 const TOOLS_DIR = new URL('../../src/tools/', import.meta.url);
 
 describe('Tool registry', () => {


### PR DESCRIPTION
Claude desktop seems to ignore the MCP and default much more strongly to chrome since a recent update.