### PR TITLE
Add a web-performance skill skill to teach profiling and analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `web-performance` plugin skill to capture a Firefox performance profile, analyze it with `profiler-cli`, trace findings to the user's source, and verify fixes by re-profiling
+
 ## [0.10.0] - 2026-08-18
 
 ### Added

--- a/plugins/firefox-devtools-mcp/skills/web-performance/SKILL.md
+++ b/plugins/firefox-devtools-mcp/skills/web-performance/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: web-performance
+description: Find and fix why a website is slow by capturing and analyzing a Firefox performance profile, or by analyzing a profile the user already has (a saved file or a profiler.firefox.com share link). Use for slow page loads, janky scrolling or animation, slow interactions or a slow STR, long tasks, layout thrashing, or heavy JavaScript.
+---
+
+Work from a real profile, find the cause in the user's code, report it honestly, and if asked, fix it and prove the fix worked. The firefox-devtools MCP drives Firefox and records a profile when there is none yet; `profiler-cli` queries the profile, whether you captured it or the user brought it. Report in web-platform terms (LCP, main-thread blocking, reflow, render-blocking resources), not Gecko internals - unless the target is Firefox itself rather than a page, in which case platform frames are the subject and the fix lands in mozilla-central.
+
+## Step 0: Prerequisites
+
+profiler-cli needs Node.js >= 24:
+```bash
+command -v profiler-cli >/dev/null 2>&1 || npm install -g @firefox-devtools/profiler-cli@latest
+```
+`npx @firefox-devtools/profiler-cli@latest` also works but re-resolves on every call.
+
+The rest of this step is only for capturing. Skip it when the user already has a profile.
+
+The profiler tools need **Firefox 154+**. Check with `get_firefox_info`, which also launches it. If Firefox is missing or older, stop and ask the user to install a current release or point the server at one with `--firefox-path`. The profiler tools also need the `developer` tool preset: if `profiler_start` is absent, ask the user to restart the server with `--tool-preset developer`, since the default `basic` preset has no profiler.
+
+## Step 1: Pick the scenario
+
+**If the user already has a profile** - a saved `.json.gz`, or a `share.firefox.dev` / profiler.firefox.com link - there is nothing to capture: skip to Step 3 and `load` it directly. Ask what they were doing while it recorded, since the capture type decides the entry point in the playbook. Verifying a fix (Step 6) still needs a capture, so if you cannot reach their setup, hand them the recipe and ask for an after profile.
+
+Otherwise ask if unclear: **page load**, **interaction / STR** (one slow action), or **ongoing jank** (scroll stutter, dropped frames, CPU pinning). Each has a recipe in `references/capture-recipes.md`.
+
+## Step 2: Capture
+
+Follow that recipe. Keep the window tight - start late, stop early - and keep the profile path `profiler_stop` returns.
+
+## Step 3: Analyze
+
+1. Run `profiler-cli guide` and read the **entire** output; it is the command reference for everything below. Do not skim, and make sure that Bash did not truncate it.
+2. `profiler-cli load <path>`, or `profiler-cli load <share-url>` for a profile the user shared.
+3. Work through `references/analysis-playbook.md`: thread selection, the entry point for each capture type, and a symptom-to-command map.
+
+Run the commands and interpret the output yourself; do not print commands for the user to run.
+
+## Step 4: Find the cause in the source
+
+`Grep`/`Glob`/`Read` the project for the code behind a hot function or request, and confirm the mechanism. If you cannot connect a finding to real source, say so instead of inventing a code path.
+
+## Step 5: Report with explicit confidence
+
+Label every finding:
+- **Confirmed** - in the profile and cross-checked (stack traced to source, a measured before/after, a `performance.measure` you captured). State the evidence.
+- **Likely** - strong single-source evidence, not cross-checked. Say what would confirm it.
+- **Hypothesis** - a plausible reading of ambiguous data. Say so, and how to validate it.
+
+If sampling is sparse, the window was wrong, or the time is mostly idle, call it inconclusive and re-capture instead of guessing.
+
+Per finding: what is slow -> evidence (function/marker/request and its cost) plus confidence -> why -> the fix in the developer's terms. Biggest confirmed wins first.
+
+When a "likely" or "hypothesis" finding is worth acting on, get more evidence first. `references/validation.md` covers instrumenting the page with User Timing and reading navigation, resource, paint, LCP and Event Timing entries.
+
+## Step 6: Fix and verify
+
+Implement only if asked, keeping the change minimal and tied to the confirmed finding. Then re-capture like-for-like (see the before/after section of the recipes) and compare the metric that was slow. Quantify the gain; if it did not improve, or something else regressed, say so and reconsider.
+
+## Step 7: Clean up
+
+`profiler-cli stop` - the daemon holds a port and memory until stopped. Stop the Firefox profiler if `profiler_is_active`, and remove instrumentation you injected unless the user wants it kept.

--- a/plugins/firefox-devtools-mcp/skills/web-performance/references/analysis-playbook.md
+++ b/plugins/firefox-devtools-mcp/skills/web-performance/references/analysis-playbook.md
@@ -1,0 +1,62 @@
+# Analysis playbook
+
+Turning a loaded profile into web-platform findings. Assumes `profiler-cli guide` has been read in full (it documents the flags used here) and the profile is loaded.
+
+## Select the right thread
+
+Start on the content process main thread: the `GeckoMain` thread of the `Isolated Web Content [<url>]` process serving the page. Most of the script, layout and paint work a user feels is there. Cross-origin iframes get their own content process, so third-party work (ads, embeds) sits under a different one; worker cost sits on `DOM Worker` threads.
+
+That is where to start, not where to stop. Depending on the problem:
+
+- **Network.** The request is not content-process work at all. `GeckoMain` in the parent process drives navigation and channel setup, and `Socket Thread` does connection, TLS and transfer, with `DNS Resolver`, `TRR Background` and `Cache2 I/O` next to it - in the parent, or in a separate `Socket` process when the build runs one. A content thread sitting idle while requests are in flight means the answer is on those threads.
+- **Scrolling, animation, dropped frames.** `Compositor`, `Renderer` and the GPU-process threads, alongside the content main thread.
+- **Firefox itself as the target.** Any platform thread can be the subject, most often parent `GeckoMain`.
+
+A thread is only in the profile if the capture recorded it: the `web-developer` preset leaves out the networking threads, so a network question usually needs a re-capture with `preset="networking"`.
+
+## Start here
+
+**Page-load captures:** `thread page-load` gives navigation timing, FCP/LCP, resources, CPU and jank periods in one view, and its marker handles feed `zoom push` and `marker info`. "No page load markers found in this thread" means the capture has no navigation or the thread is wrong - it is not a verdict about the page.
+
+**Interaction and jank captures** never navigate, so `page-load` returns nothing for them. Enter through markers:
+
+```
+profiler-cli thread markers --min-duration 50 --list   # long intervals, chronological
+profiler-cli zoom push m-<handle>                      # onto the worst one
+profiler-cli thread samples-top-down                   # what ran during it
+```
+
+Blocking main-thread work appears as a long `Runnable`, or `Perform microtasks`. `DOMEvent` markers locate the interaction. Ignore long-lived span markers that are not blocking work: `Image Animation` (one animating GIF spans the whole recording), `IPC Accumulator`. `--has-stack` with `marker stack <handle>` gives the stack that belongs to a marker.
+
+## Minified bundles: apply the source map first
+
+If JS frames show mangled names (`a`, `t.exports`), de-minify before reading stacks.
+
+```
+profiler-cli sourcemap sources                  # bundles with a source map, as src-N, plus their sourceMapURL
+profiler-cli sourcemap apply dist/bundle.js.map
+```
+
+`apply` reads a local file, it does not fetch: take the `.map` from the user's build output, and if `sources` shows a remote `sourceMapURL`, download it first. It rewrites stacks in place, so apply before reading call trees. The guide's SOURCE MAPS section covers `--to src-N` and ambiguous matches. With no map, keep findings at function level - mangled names do not support line-level claims.
+
+## Symptom -> where to look
+
+**Do not limit yourself to the categories below.** They are the common cases, not a list of the problems a profile can answer. The data decides what the problem is; if the symptom does not match any of them, or the profile points somewhere else, follow the profile. Forcing a finding into one of these buckets is how you end up reporting the wrong cause.
+
+**Slow first paint / LCP / content appears late.** `thread page-load` for which phase dominates. Before first byte is server or network; between response and paint is client work. `thread markers` shows when paint, DOMContentLoaded and load actually fired.
+
+**Long tasks / blocked main thread / unresponsive UI.** Take long tasks from the profile: `page-load` jank periods for a navigation capture, the marker route above otherwise. `samples-bottom-up` complements the top-down tree by showing hot leaf functions and their callers. If the hot frames are framework internals (render, reconcile, hydrate), look for too many or too expensive components rather than one slow function.
+
+**Heavy JavaScript.** `thread functions` for a flat list by CPU percentage, `samples-top-down` for the tree, `function annotate <handle>` for per-line timing, `function expand <handle>` for a truncated name.
+
+**Layout thrashing / forced reflow.** In `samples-top-down`, look for reflow/layout/style-recalc frames interleaved with script - that pattern is a script reading layout, writing, then reading again, forcing synchronous reflow. `thread markers` shows how often layout and reflow markers fire. Then find the read-write-read loop in the source.
+
+**Slow or render-blocking network.** `thread network` gives per-request timing phases (DNS, connect, TLS, wait, download) for the selected thread. Look for render-blocking CSS/JS in the head, long TTFB, request chains where each waits on the previous, and duplicate downloads. When the cost is in the transfer itself rather than in how the page requested it, follow it onto the parent's `GeckoMain` and `Socket Thread` as described above. The profile has timing but not response headers, so for `content-encoding`, `cache-control` and `content-type` - what tells you whether an asset is actually compressed or cacheable - use the MCP's `list_network_requests` and `get_network_request`.
+
+**User Timing.** `thread markers` shows the developer's `performance.mark`/`measure` alongside platform markers; `marker info` and `marker stack` give one marker's detail and its stack.
+
+**Anything else.** Let the profile pick the direction: `profile info` for which process and thread actually burned CPU or stalled, then markers and samples on that thread.
+
+## Before recommending a fix
+
+Correlate the hot stack with markers and network timing. A stack alone says what ran, rarely why it ran.

--- a/plugins/firefox-devtools-mcp/skills/web-performance/references/capture-recipes.md
+++ b/plugins/firefox-devtools-mcp/skills/web-performance/references/capture-recipes.md
@@ -1,0 +1,53 @@
+# Capture recipes
+
+Record the right profile per scenario. If a capture misses the slow moment or is mostly idle, re-capture instead of salvaging it.
+
+Applies to every recipe:
+- Firefox launches lazily on the first MCP call (`list_pages`, `get_firefox_info`). Reuse the existing session and tab; only `new_page` / `navigate_page` for a different page or a clean state.
+- `preset="web-developer"` is the usual choice for `profiler_start`, but it does not record the networking threads. A network-shaped problem (slow TTFB, connection or TLS setup, DNS, cache misses) might want `networking` instead. Use `firefox-platform` when the target is Firefox itself, another preset when the problem sits squarely in its domain, or explicit `entries`/`interval`/`features`/`threads` when none of them fit.
+- `profiler_stop` saves to Firefox's downloads directory and returns the path. Keep it.
+- If nothing records, check `profiler_is_active` and confirm Firefox is 154+.
+
+## Page load
+
+The recording should span one navigation with nothing before it.
+
+1. `navigate_page url="about:blank"`, so the navigation is captured from the start.
+2. `profiler_start`.
+3. `navigate_page url="https://the-page"` - this navigation is the whole recording.
+4. Wait for the page to finish, then stop promptly without recording an idle tail. There is no wait tool, so poll: `evaluate_script function="() => [document.readyState, performance.getEntriesByType('navigation')[0]?.loadEventEnd]"`, or `screenshot_page`.
+5. `profiler_stop`.
+
+Caching caveat: this is a clean navigation but not a cold load. The session shares Firefox's HTTP cache, and `about:blank` or a new tab does not clear it. Neither can you: there is no cache-clearing or private-window tool. So either:
+- label the finding a warm-cache load, or
+- for a real first visit, `restart_firefox` with `profilePath` set to a fresh empty directory - a new profile starts with an empty cache, but it closes every tab and drops cookies and logins, so it is no good for authenticated pages.
+
+Confirm which one you got instead of assuming: in `thread network`, a cold load shows real DNS/connect/download phases for subresources, a warm one near-zero fetch time.
+
+Warm variant (repeat visit): navigate to the URL and let it settle first, then start the profiler and navigate to it again. The second navigation is the measured one.
+
+## Interaction or STR
+
+Record the action, not the setup.
+
+1. `navigate_page` to the state right before the slow action. Do NOT perform it yet.
+2. `take_snapshot` to resolve the UIDs you will need, so the recorded window is only the action.
+3. `profiler_start`.
+4. Perform exactly the steps the user reports as slow, in order, with the automation tools.
+5. `profiler_stop` as soon as the slow result is visible.
+
+If the DOM changed and you need a fresh snapshot mid-recording, `take_snapshot` again; it does not meaningfully pollute the profile.
+
+## Ongoing jank (scroll, animation, CPU pinning)
+
+1. `navigate_page` to the janky page and state.
+2. `profiler_start`.
+3. Reproduce the jank for a few representative seconds. Drive the scrolling if you can, otherwise ask the user to scroll while recording.
+4. `profiler_stop`.
+
+## Re-capturing to verify a fix
+
+The second capture must be like-for-like or the comparison is meaningless:
+- Same recipe, URL, STR steps and window length.
+- Same cache warmth and page state; a cold-vs-warm difference will swamp the fix.
+- Ideally the same `performance.mark`/`measure` instrumentation (see `validation.md`), so you compare the same measured span rather than two eyeballed windows.

--- a/plugins/firefox-devtools-mcp/skills/web-performance/references/validation.md
+++ b/plugins/firefox-devtools-mcp/skills/web-performance/references/validation.md
@@ -1,0 +1,35 @@
+# Validation: turning guesses into measurements
+
+Use this when a "likely" or "hypothesis" finding matters enough to act on, or to get a reliable metric for a before/after comparison. Instrumentation goes into the user's source where there is source to edit, and through `evaluate_script` otherwise.
+
+## Bracket the operation with User Timing
+
+Marks and measures appear both as markers in the next captured profile and via `performance.getEntriesByType('measure')`.
+
+**If the user's source is available, put the marks there instead.** They then measure only the operation, can wrap code you cannot reach from the outside, survive a navigation, and are still in place for the after-fix capture, so both runs measure the same span.
+
+With no source to edit, bracket from outside while the profiler records:
+
+1. `performance.mark('before')`, then perform the STR step with the automation tools.
+2. `performance.mark('after')` and `performance.measure('op', 'before', 'after')`.
+3. Read back with `evaluate_script function="() => performance.getEntriesByType('measure').map(m => ({name: m.name, dur: m.duration}))"`, and find the same span in the profile with `thread markers --search op`.
+
+Those are three separate tool calls, so the measure also contains the MCP round-trips and your own thinking time between them. Treat it as a way to locate the span in the profile, not as the operation's cost.
+
+A measured duration matching the sampled cost confirms the finding; a mismatch means sampling misattributed it, which is common with inlined or minified code.
+
+## LCP and Event Timing
+
+Firefox might not support every entry type Chrome does, and `observe()` ignores an unsupported one with a console warning and no exception - you get an empty result that reads like a clean bill of health. Check before relying on one, rather than assuming the Chrome set:
+
+`evaluate_script function="() => PerformanceObserver.supportedEntryTypes"`
+
+Anything missing from that list has to come from the profile instead.
+
+An observer needs a document, and `evaluate_script` runs in the *current* one - a navigation destroys it along with anything on `window`. For a page load, install the observer *after* the navigation settles; `buffered: true` replays entries that already fired, so nothing is missed. For an STR, install it before the action.
+
+```
+evaluate_script function="() => { window.__perf = {lcp: 0, events: []}; new PerformanceObserver(l => { for (const e of l.getEntries()) window.__perf.lcp = e.startTime; }).observe({type: 'largest-contentful-paint', buffered: true}); new PerformanceObserver(l => { for (const e of l.getEntries()) window.__perf.events.push({name: e.name, dur: e.duration}); }).observe({type: 'event', buffered: true, durationThreshold: 16}); }"
+```
+
+Read back with `evaluate_script function="() => window.__perf"`. The last LCP entry wins; `event` entries give per-interaction latency.


### PR DESCRIPTION
This patch adds a new skill called `web-performance`, to profile a website with the firefox-devtools MCP, analyze the capture with profiler-cli, trace findings to the user's source, and verify fixes by re-profiling. Includes references for capture recipes, an analysis playbook, and validating findings with User Timing.